### PR TITLE
Fixed typo (srong->strong) in develop page

### DIFF
--- a/scripts/src/lib/Versions.svelte
+++ b/scripts/src/lib/Versions.svelte
@@ -106,7 +106,7 @@ fabric_version={apiVersion}
 
 <h4>Loom</h4>
 
-<p>The recommended loom version is <srong>0.12-SNAPSHOT</srong>. This is usually defined near the top of your  build.gradle file.</p>
+<p>The recommended loom version is <strong>0.12-SNAPSHOT</strong>. This is usually defined near the top of your  build.gradle file.</p>
 
 <style>
     .copy-code {


### PR DESCRIPTION
There was a typo in one of the tags on the develop page.