### PR TITLE
Load main script as module

### DIFF
--- a/_layouts/use.html
+++ b/_layouts/use.html
@@ -75,5 +75,5 @@ layout: page
     </ul>
 </div>
 
-<script type="text/javascript" src="/scripts/main.js"></script>
+<script type="module" src="/scripts/main.js"></script>
 <link href="/scripts/style.css" rel="stylesheet">

--- a/develop.md
+++ b/develop.md
@@ -25,5 +25,5 @@ This page contains a range of resources to help you create a new mod or maintain
 <noscript style="color:red">You need Javascript to show the documentation links</noscript>
 <div class="fabric-component" data-component="Documentation"></div>
 
-<script type="text/javascript" src="/scripts/main.js"></script>
+<script type="module" src="/scripts/main.js"></script>
 <link href="/scripts/style.css" rel="stylesheet">


### PR DESCRIPTION
The way I understand it, Vite is configured to export it as an ES module and uses them internally, so the entrypoint should be loaded as such.

Probably resolves #7, though I don't know what prompted the script to load twice in the same context.

Please test locally before merging.