### PR TITLE
Updated code example to use FabricDataOutput

### DIFF
--- a/_posts/2022-11-24-1193.md
+++ b/_posts/2022-11-24-1193.md
@@ -110,8 +110,8 @@ Data generator constructors now take `FabricDataOutput` as an argument instead o
 
 ```java
 public class TestBlockLootTableProvider extends FabricBlockLootTableProvider {
-    public TestBlockLootTableProvider(FabricDataGenerator dataGenerator) {
-        super(dataGenerator);
+    public TestBlockLootTableProvider(FabricDataOutput dataOutput) {
+        super(dataOutput);
     }
 
     @Override
@@ -126,8 +126,8 @@ For tag generators, the constructor must also take `CompletableFuture<RegistryWr
 
 ```java
 public class TestBiomeTagProvider extends FabricTagProvider<Biome> {
-    public TestBiomeTagProvider(FabricDataOutput output, CompletableFuture<RegistryWrapper.WrapperLookup> registriesFuture) {
-        super(output, RegistryKeys.BIOME, registriesFuture);
+    public TestBiomeTagProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registriesFuture) {
+        super(dataOutput, RegistryKeys.BIOME, registriesFuture);
     }
 
     @Override


### PR DESCRIPTION
Updated code example to use FabricDataOutput as described in the documentation
Renamed output to dataOutput for consistency between examples