### PR TITLE
template: Use `fabric_api_version` instead of `fabric_version`

### DIFF
--- a/scripts/src/lib/template/template.ts
+++ b/scripts/src/lib/template/template.ts
@@ -35,7 +35,7 @@ export interface KotlinConfiguration {
 export interface ComputedConfiguration extends Configuration {
 	modid: string,
 	loaderVersion: string,
-	fabricVersion: string,
+	fabricApiVersion: string,
 	yarnVersion: string,
 	kotlin: KotlinConfiguration | undefined
 }
@@ -65,7 +65,7 @@ async function computeConfig(options: Configuration): Promise<ComputedConfigurat
 	return {
 		...options,
 		loaderVersion: (await getLoaderVersions()).find((v) => v.stable)!.version,
-		fabricVersion: await getApiVersionForMinecraft(options.minecraftVersion),
+		fabricApiVersion: await getApiVersionForMinecraft(options.minecraftVersion),
 		yarnVersion: (await getMinecraftYarnVersions(options.minecraftVersion))[0].version,
 		kotlin: await computeKotlinOptions(options)
 	};

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -59,12 +59,12 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 	<% if (it.kotlin) { %>modImplementation "net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}"<% } %>
 	// Uncomment the following line to enable the deprecated Fabric API modules. 
 	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
 
-	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
+	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_api_version}"
 }
 
 processResources {

--- a/scripts/src/lib/template/templates/gradle/groovy/gradle.properties.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/gradle.properties.eta
@@ -15,4 +15,4 @@ maven_group=<%= it.packageName %>
 archives_base_name=<%= it.modid %>
 
 # Dependencies
-fabric_version=<%= it.fabricVersion %>
+fabric_api_version=<%= it.fabricApiVersion %>


### PR DESCRIPTION
The mod's identifier was changed to fabric-api back in August, so I feel like for the sake of consistency, that the website should use fabric-api when referencing its version property in the configuration as well.