### PR TITLE
Fixes #30 #28 #31 #32 #33 #36 and some of #35

### DIFF
--- a/scripts/src/lib/Template.svelte
+++ b/scripts/src/lib/Template.svelte
@@ -92,7 +92,7 @@
     }
 
     async function generate() {
-        if (modIdErrors != undefined) {
+        if (modIdErrors != undefined || modid === "") {
             return;
         }
 
@@ -156,6 +156,10 @@
             {/if}
             
             <input id="project-name" bind:value={projectName} />
+            
+            {#if modid === ""}
+              <p style="color: red">The Modname can not be empty!</p>
+            {/if}
         </div>
 
         {#if customModId != undefined}

--- a/scripts/src/lib/Template.svelte
+++ b/scripts/src/lib/Template.svelte
@@ -114,14 +114,14 @@
         await generator.generateTemplate({
             config,
             writer: {
-                write: async (path, content) => {
-                    zip.file(path, content);
+                write: async (path, content, options) => {
+                    zip.file(path, content, options);
                 },
             },
         });
 
         FileSaver.saveAs(
-            await zip.generateAsync({ type: "blob" }),
+            await zip.generateAsync({ type: "blob", platform: "UNIX" }),
             `${modid}-template-${config.minecraftVersion}.zip`
         );
 

--- a/scripts/src/lib/template/gradlewrapper.ts
+++ b/scripts/src/lib/template/gradlewrapper.ts
@@ -9,7 +9,9 @@ import gitignore from './templates/git/gitignore?raw';
 import workflow from './templates/git/workflow.yml?raw'
 
 export async function addGradleWrapper({ writer }: Options) {
-	await writer.write('gradlew', gradlew);
+	await writer.write('gradlew', gradlew, {
+    unixPermissions: "774"
+  });
 	await writer.write('gradlew.bat', gradlewBat);
 	await writer.write('gradle/wrapper/gradle-wrapper.properties', gradleWrapperProperties);
 	await writer.write('gradle/wrapper/gradle-wrapper.jar', decode64(gradleWrapperJar));

--- a/scripts/src/lib/template/template.ts
+++ b/scripts/src/lib/template/template.ts
@@ -3,6 +3,7 @@ import { addGroovyGradle } from './gradlegroovy';
 import { getApiVersionForMinecraft, getKotlinAdapterVersions, getLoaderVersions, getMinecraftYarnVersions } from '../Api';
 import { addModJson } from './modjson';
 import { addGitFiles } from './git';
+import type { JSZipFileOptions } from 'jszip';
 
 export interface Options {
 	/**
@@ -45,7 +46,7 @@ export interface TemplateOptions {
 }
 
 export interface TemplateWriter {
-	write(path: string, content: string | ArrayBufferLike): Promise<void>
+	write(path: string, content: string | ArrayBufferLike, options?: JSZipFileOptions): Promise<void>
 }
 
 export async function generateTemplate(options: Options) {

--- a/scripts/src/lib/template/template.ts
+++ b/scripts/src/lib/template/template.ts
@@ -58,7 +58,7 @@ export async function generateTemplate(options: Options) {
 }
 
 export function nameToModId(name: string) {
-	return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-za-z0-9-_]/, "");
+	return name.toLowerCase().replaceAll(/\s+/g, '-').replaceAll(/[^a-za-z0-9-_]/g, "");
 }
 
 async function computeConfig(options: Configuration): Promise<ComputedConfiguration> {

--- a/scripts/src/lib/template/templates/entrypoint/ClientEntrypoint.java.eta
+++ b/scripts/src/lib/template/templates/entrypoint/ClientEntrypoint.java.eta
@@ -3,8 +3,8 @@ package <%= it.package %>;
 import net.fabricmc.api.ClientModInitializer;
 
 public class <%= it.className %> implements ClientModInitializer {
-	@Override
-	public void onInitializeClient() {
-		// This entrypoint is suitable for setting up client-specific logic, such as rendering.
-	}
+    @Override
+    public void onInitializeClient() {
+        // This entrypoint is suitable for setting up client-specific logic, such as rendering.
+    }
 }

--- a/scripts/src/lib/template/templates/entrypoint/ClientEntrypoint.kt.eta
+++ b/scripts/src/lib/template/templates/entrypoint/ClientEntrypoint.kt.eta
@@ -3,7 +3,7 @@ package <%= it.package %>
 import net.fabricmc.api.ClientModInitializer
 
 object <%= it.className %> : ClientModInitializer {
-	override fun onInitializeClient() {
-		// This entrypoint is suitable for setting up client-specific logic, such as rendering.
-	}
+    override fun onInitializeClient() {
+        // This entrypoint is suitable for setting up client-specific logic, such as rendering.
+    }
 }

--- a/scripts/src/lib/template/templates/entrypoint/DataGeneratorEntrypoint.java.eta
+++ b/scripts/src/lib/template/templates/entrypoint/DataGeneratorEntrypoint.java.eta
@@ -4,8 +4,8 @@ import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 
 public class <%= it.className %> implements DataGeneratorEntrypoint {
-	@Override
-	public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
+    @Override
+    public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
 
-	}
+    }
 }

--- a/scripts/src/lib/template/templates/entrypoint/DataGeneratorEntrypoint.kt.eta
+++ b/scripts/src/lib/template/templates/entrypoint/DataGeneratorEntrypoint.kt.eta
@@ -4,6 +4,6 @@ import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
 
 object <%= it.className %> : DataGeneratorEntrypoint {
-	override fun onInitializeDataGenerator(fabricDataGenerator: FabricDataGenerator) {
-	}
+    override fun onInitializeDataGenerator(fabricDataGenerator: FabricDataGenerator) {
+    }
 }

--- a/scripts/src/lib/template/templates/entrypoint/Entrypoint.java.eta
+++ b/scripts/src/lib/template/templates/entrypoint/Entrypoint.java.eta
@@ -9,17 +9,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 <% } %>
 public class <%= it.className %> implements ModInitializer {
-	// This logger is used to write text to the console and the log file.
-	// It is considered best practice to use your mod id as the logger's name.
-	// That way, it's clear which mod wrote info, warnings, and errors.
-<% if (it.slf4j) { %>	public static final Logger LOGGER = LoggerFactory.getLogger("<%= it.modid %>");
-<% } else { %>	public static final Logger LOGGER = LogManager.getLogger("<%= it.modid %>");<% } %>
-	@Override
-	public void onInitialize() {
-		// This code runs as soon as Minecraft is in a mod-load-ready state.
-		// However, some things (like resources) may still be uninitialized.
-		// Proceed with mild caution.
+    // This logger is used to write text to the console and the log file.
+    // It is considered best practice to use your mod id as the logger's name.
+    // That way, it's clear which mod wrote info, warnings, and errors.
+<% if (it.slf4j) { %>    public static final Logger LOGGER = LoggerFactory.getLogger("<%= it.modid %>");
+<% } else { %>    public static final Logger LOGGER = LogManager.getLogger("<%= it.modid %>");<% } %>
+    @Override
+    public void onInitialize() {
+        // This code runs as soon as Minecraft is in a mod-load-ready state.
+        // However, some things (like resources) may still be uninitialized.
+        // Proceed with mild caution.
 
-		LOGGER.info("Hello Fabric world!");
-	}
+        LOGGER.info("Hello Fabric world!");
+    }
 }

--- a/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
+++ b/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
@@ -4,12 +4,12 @@ import net.fabricmc.api.ModInitializer
 <% if (it.slf4j) { %>import org.slf4j.LoggerFactory
 <% } else { %>import org.apache.logging.log4j.LogManager<% } %>
 object <%= it.className %> : ModInitializer {
-<% if (it.slf4j) { %>	private val logger = LoggerFactory.getLogger("<%= it.modid %>")
-<% } else { %>	private val logger = LogManager.getLogger("<%= it.modid %>")<% } %>
-	override fun onInitialize() {
-		// This code runs as soon as Minecraft is in a mod-load-ready state.
-		// However, some things (like resources) may still be uninitialized.
-		// Proceed with mild caution.
-		logger.info("Hello Fabric world!")
-	}
+<% if (it.slf4j) { %>    private val logger = LoggerFactory.getLogger("<%= it.modid %>")
+<% } else { %>    private val logger = LogManager.getLogger("<%= it.modid %>")<% } %>
+    override fun onInitialize() {
+        // This code runs as soon as Minecraft is in a mod-load-ready state.
+        // However, some things (like resources) may still be uninitialized.
+        // Proceed with mild caution.
+        logger.info("Hello Fabric world!")
+    }
 }

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -1,7 +1,9 @@
 plugins {
 	id 'fabric-loom' version '1.1-SNAPSHOT'
 	id 'maven-publish'
-	<%_ if (it.kotlin) { %>id "org.jetbrains.kotlin.jvm" version "<%= it.kotlin.kotlinVersion %>"<% } %>
+	<%_ if (it.kotlin) { %>
+  id "org.jetbrains.kotlin.jvm" version "<%= it.kotlin.kotlinVersion %>"
+  <%_ } %>
 }
 
 sourceCompatibility = JavaVersion.<%= it.java.compatibility %>

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -23,7 +23,7 @@ loom {
 <% if (it.splitSources) { %>    splitEnvironmentSourceSets()
 
     mods {
-        modid {
+        "<%= it.modid %>" {
             sourceSet sourceSets.main
             sourceSet sourceSets.client
         }

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -1,7 +1,7 @@
 plugins {
 	id 'fabric-loom' version '1.1-SNAPSHOT'
 	id 'maven-publish'
-	<% if (it.kotlin) { %>id "org.jetbrains.kotlin.jvm" version "<%= it.kotlin.kotlinVersion %>"<% } %>
+	<%_ if (it.kotlin) { %>id "org.jetbrains.kotlin.jvm" version "<%= it.kotlin.kotlinVersion %>"<% } %>
 }
 
 sourceCompatibility = JavaVersion.<%= it.java.compatibility %>


### PR DESCRIPTION
Just a round of fixes, I wanna try to add some of the feature recommended in #35 and #38, but I didn't get round to those this time round.

- #30 Fixed the regex matcher to match all instead of only some
- #26 Added -x (execute) unix permission for the `gradlew` file. This did require us to move over to using JSZip in platform: 'UNIX' mode, but I can't see any relevant downsides from this change. 
- #31 / #32 Moved some code around to support validation rules on both modId inputs to improve basic error checking on the generated modid field as well
- #35 Switched out the tab char's for spaces, I can reset this one if we don't like the change but it is more standard for Java IIRC
- #36 Use a "$modId" for the classPath Group in gradle. Using the quotes should allow for more room for more abnormal mod names.