### PR TITLE
Update 1.20 blogpost

### DIFF
--- a/_posts/2023-05-25-120.md
+++ b/_posts/2023-05-25-120.md
@@ -3,7 +3,7 @@ layout: post
 title: Fabric for Minecraft 1.20
 ref: 120
 ---
-Minecraft 1.20 is almost here, again with a number of changes that impact many mods.
+Minecraft 1.20 - the Trails and Tales Update - [releases on June 7th 2023](https://www.minecraft.net/en-us/article/trails-tales-update-coming), again with a number of changes that impact many mods.
 
 As usual, we ask players to be patient, and give mod developers time to update to this new version.
 
@@ -120,7 +120,7 @@ In addition, various rendering methods now take `DrawContext` instead of `Matrix
 
 Fabric API changes related to this:
 
-- Rendering API's `HudRenderCallback`, Screen API's `ScreenEvents.beforeRender`, and `ScreenEvents.beforeRender` now take `DrawContext` instead of `MatrixStack`.
+- Rendering API's `HudRenderCallback`, Screen API's `ScreenEvents.beforeRender`, and `ScreenEvents.afterRender` now take `DrawContext` instead of `MatrixStack`.
 - `Screens.getItemRenderer` is removed. This can be easily replaced with `MinecraftClient#getItemRenderer`, although this is usually not necessary.
 
 And one unrelated change: `Screen#passEvents` was removed, therefore screens can no longer pass events.
@@ -174,5 +174,4 @@ Predicates and item modifiers (or, in legacy terms, loot conditions and loot fun
 - Fabric Content Registries' `VillagerPlantableRegistry` was replaced with `ItemTags.VILLAGER_PLANTABLE_SEEDS` (data pack tags).
 - Herobrine was removed.
 - `RecipeProvider#offerWoolDyeingRecipe` and similar methods were merged to `offerDyeableRecipes` (which also offers re-coloring).
-- Ingredients can now be `minecraft:air` to indicate an empty slot. If your code uses `Ingredient#fromJson`, then it will automatically allow air ingredients. **To keep old behavior** of disallowing air ingredients (which you probably want), use the `fromJson` overload with the boolean param set to `false`.
 - `ServerCommandSource#sendFeedback` now takes `Supplier<Text>` instead of `Text` for performance reasons. Add `() ->` and it should be good to go.


### PR DESCRIPTION
- Add update name and release date, with a link to the release date Mojang blogpost
- Fix `beforeRender` being mentioned twice in lieu of `afterRender`
- Remove mention of outdated (and now incorrect) ingredient change