### PR TITLE
Misc website and template improvements

### DIFF
--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -107,9 +107,18 @@ async function promptUser(
 
   const packageName: string = await Input.prompt({
     message: "Choose a package name",
-    default: modId,
+    default: generator.formatPackageName(modId),
     transform: (value) => {
       return generator.formatPackageName(value);
+    },
+    validate: (value) => {
+      const errors = generator.computePackageNameErrors(value);
+
+      if (errors.length == 0) {
+        return true;
+      }
+
+      return errors.join(", ");
     },
   });
 

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-net
+#!/usr/bin/env -S deno run -A
 
 // @deno-types="../scripts/dist/fabric-template-generator.d.ts"
 import * as generator from "../scripts/dist/fabric-template-generator.js";

--- a/scripts/src/lib.ts
+++ b/scripts/src/lib.ts
@@ -1,3 +1,4 @@
 export * from './lib/Api';
 export * from './lib/template/template';
 export * from './lib/template/minecraft';
+export * from './lib/template/java';

--- a/scripts/src/lib/Template.svelte
+++ b/scripts/src/lib/Template.svelte
@@ -4,6 +4,7 @@
     import DownloadIcon from "./DownloadIcon.svelte";
     import { getTemplateGameVersions } from "./template/template";
     import { minecraftSupportsDataGen, minecraftSupportsSplitSources, computeCustomModIdErrors, sharedModIdChecks, formatPackageName, nameToModId} from "./template/minecraft";
+    import { computePackageNameErrors } from "./template/java"
 
     let minecraftVersion: string;
     let projectName = "Template Mod";
@@ -30,6 +31,7 @@
 
     $: modIdErrors = computeModIdErrors(modid);
     $: customIdErrors = computeCustomModIdErrors(customModId);
+    $: packageNameErrors = computePackageNameErrors(packageName);
 
     function computeModIdErrors(id: string | undefined) : string[] | undefined {
       if (id === undefined) {
@@ -40,7 +42,7 @@
     }
 
     async function generate() {
-        if (modIdErrors !== undefined || (customModId !== undefined && customIdErrors !== undefined)) {
+        if (modIdErrors !== undefined || (customModId !== undefined && customIdErrors !== undefined) || packageNameErrors.length > 0) {
             return;
         }
 
@@ -112,11 +114,11 @@
             <input id="project-name" bind:value={projectName} on:keyup={doFormatProjectName} />
 
             {#if modIdErrors != undefined}
-            {#each modIdErrors as error}
-                <li style="color: red">{error}</li>
-            {/each}
-            <br>
-        {/if}
+                {#each modIdErrors as error}
+                    <li style="color: red">{error}</li>
+                {/each}
+                <br>
+            {/if}
         </div>
 
         {#if customModId != undefined}
@@ -143,6 +145,10 @@
                 should be unique to you. If you are unsure about this use <code>name.modid</code>.
             </p>
             <input id="package-name" on:keyup={doFormatPackageName} bind:value={packageName} />
+
+            {#each packageNameErrors as error}
+                <li style="color: red">{error}</li>
+            {/each}
         </div>
 
         <div class="form-line">
@@ -213,7 +219,7 @@
             </a>
         {:else}
             <a
-                class="button primary download-button"
+                class="button primary large download-button"
                 href={""}
                 on:click|preventDefault={generate}
             >

--- a/scripts/src/lib/Versions.svelte
+++ b/scripts/src/lib/Versions.svelte
@@ -14,7 +14,8 @@
 
     let gameVersions = getGameVersions().then((versions) => {
         minecraftVersion = versions.find((v) => v.stable)!.version
-        return versions.map((v) => v.version);
+        const latestVersion = versions[0];
+        return versions.filter((v) => v.stable || v == latestVersion).map((v) => v.version);
     });
 
     const loaderVersions = getLoaderVersions().then((versions) => {

--- a/scripts/src/lib/template/java.ts
+++ b/scripts/src/lib/template/java.ts
@@ -39,3 +39,24 @@ export function getJavaVersion(minecraftVersion: string): JavaVersion {
 
 	return JAVA_17;
 }
+
+const JAVA_PACKAGE_REGEX = /^[a-zA-Z]+(\.[a-zA-Z][a-zA-Z0-9]*)*$/;
+const RESERVED_PACKAGE_PREFIXES = ["net.minecraft.", "com.mojang.", "net.fabricmc.", "java."];
+
+export function computePackageNameErrors(packageName: string): string[] {
+	let errorList : string[] = [];
+
+	if (!JAVA_PACKAGE_REGEX.test(packageName)) {
+		errorList.push("Package name is not a valid Java package name!");
+	}
+
+	for (let prefix of RESERVED_PACKAGE_PREFIXES) {
+		if (packageName.toLowerCase().startsWith(prefix)) {
+			errorList.push(`Package name starts with '${prefix}', which is reserved!`);
+		} else if (packageName.toLowerCase() + "." == prefix) {
+			errorList.push(`Package name is '${prefix}', which is reserved!`);
+		}
+	}
+
+	return errorList;
+}

--- a/scripts/src/lib/template/minecraft.ts
+++ b/scripts/src/lib/template/minecraft.ts
@@ -22,6 +22,10 @@ export function sharedModIdChecks(id: string, isId: boolean): string[] | undefin
 		errorList.push(`${type} has more than 64 characters!`);
 	}
 
+	if (id.toLocaleLowerCase().startsWith("fabric")) {
+		errorList.push("Mod id starts with 'fabric', which is generally reserved for Fabric itself.")
+	}
+
 	return errorList.length === 0 ? undefined : errorList;
 }
 

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -20,7 +20,7 @@ repositories {
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
 }
-<% if (it.dataGeneration || it.splitSources) { %>
+<% if (it.splitSources) { %>
 loom {
 <% if (it.splitSources) { %>    splitEnvironmentSourceSets()
 
@@ -30,30 +30,13 @@ loom {
 			sourceSet sourceSets.client
 		}
 	}
-<% } %><% if (it.dataGeneration) { %>    runs {
-		// This adds a new gradle task that runs the datagen API: "gradlew runDatagen"
-		datagen {
-			inherit server
-			name "Data Generation"
-			vmArg "-Dfabric-api.datagen"
-			vmArg "-Dfabric-api.datagen.output-dir=${file("src/main/generated")}"
-			vmArg "-Dfabric-api.datagen.modid=<%= it.modid %>"
- 
-			runDir "build/datagen"
-		}
-	}<% } %>
+<% } %>
 }
 <% } %><% if (it.dataGeneration) { %>
-// Add the generated resources to the main source set
-sourceSets {
-	main {
-		resources {
-			srcDirs += [
-					'src/main/generated'
-			]
-		}
-	}
-}<% } %>
+fabricApi {
+	configureDataGeneration()
+}
+<% } %>
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"


### PR DESCRIPTION
- Valdate package name
  - Must be a valid java package name 
  - Must not start with `net.minecraft.`, `com.mojang.`, `net.fabricmc.` or `java.`
- Dont allow mod ids that start with `fabric`
- Only show the latest snapshot on the develop page, closes #67 
- Use `fabricApi.configureDataGeneration` DSL closes #60 