### PR TITLE
Set artifactId for publishing

### DIFF
--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -86,6 +86,7 @@ jar {
 publishing {
 	publications {
 		create("mavenJava", MavenPublication) {
+			artifactId = project.archives_base_name
 			from components.java
 		}
 	}


### PR DESCRIPTION
Sets the `artifactId` for publishing or else it defaults to the directory name, which is not ideal*.  

\*For example, GitHub Packages reject an `artifactId` with capital letters and produce an obscure 422 unprocessable entity, which is very difficult to track down.

## Testing
Tested [here](https://github.com/kevinthegreat1/GameRuleLib/blob/main/build.gradle#L77) and published [here](https://github.com/kevinthegreat1/GameRuleLib/packages/2122063).

## Future Improvements
`groupId` is currently `com.organization.artifactId` and could be changed to `com.organization`, but the implications of such change is unknown, and therefore not covered by this pr.