### PR TITLE
Set `escapeBackslash` for `fabric.mod.json` variable expansion

### DIFF
--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -52,7 +52,9 @@ processResources {
 	inputs.property "version", project.version
 
 	filesMatching("fabric.mod.json") {
-		expand "version": inputs.properties.version
+		expand("version": inputs.properties.version) {
+			escapeBackslash = true
+		}
 	}
 }
 


### PR DESCRIPTION
The file seems to be parsed in some capacity, as without this change, the sequence `\n` (just in the file, not even in the interpolated variable) is replaced with a literal newline, which by the JSON spec isn't allowed in strings.

~~see also FabricMC/fabric-example-mod#282~~