### PR TITLE
Fix blog post networking code

### DIFF
--- a/_posts/2024-04-19-1205.md
+++ b/_posts/2024-04-19-1205.md
@@ -334,9 +334,9 @@ var nbt = PacketCodecs.NBT_COMPOUND;
 
 // Serializing a registry value (by raw ID)
 // Note: these require RegistryByteBuf!
-PacketCodecs<RegistryByteBuf, Item> item = PacketCodecs.registryValue(RegistryKeys.ITEM);
+PacketCodec<RegistryByteBuf, Item> item = PacketCodecs.registryValue(RegistryKeys.ITEM);
 // Or, RegistryEntry
-PacketCodecs<RegistryByteBuf, Biome> biome = PacketCodecs.registryEntry(RegistryKeys.BIOME);
+PacketCodec<RegistryByteBuf, Biome> biome = PacketCodecs.registryEntry(RegistryKeys.BIOME);
 
 // Serializing an Enum
 var axis = PacketCodecs.indexed(i -> Direction.Axis.VALUES[i], Direction.Axis::ordinal);
@@ -400,12 +400,12 @@ Then, you can change the receiver. Instead of long parameters, the event callbac
 
 Here are the available fields in the context object:
 
-| `PayloadTypeRegistry` | Class                  | Fields                               |
-| --------------------- | ---------------------- | ------------------------------------ |
-| `playC2S`             | `ServerPlayNetworking` | `player`, `responseSender`           |
-| `playS2C`             | `ClientPlayNetworking` | `client`, `player`, `responseSender` |
-| `configurationC2S`    | `ServerConfigurationNetworking`               |        `networkHandler`, `responseSender`   |
-| `configurationS2C`                  | `ClientConfigurationNetworking`                  | `responseSender`                                 |
+| `PayloadTypeRegistry` | Class                           | Fields               |
+|-----------------------|---------------------------------|----------------------|
+| `playC2S`             | `ServerPlayNetworking`          | `payload`, `context` |
+| `playS2C`             | `ClientPlayNetworking`          | `payload`, `context` |
+| `configurationC2S`    | `ServerConfigurationNetworking` | `payload`, `context` |
+| `configurationS2C`    | `ClientConfigurationNetworking` | `payload`, `context` |
 
 Note that the field shortcuts might be added later.
 


### PR DESCRIPTION
Fixes two mistakes in example code:  

Instance should be `PacketCodec<>` and not `PacketCodecs<>`.  

All play and config networking receivers take `payload` and `context`.  