### PR TITLE
Add rendering argb changes

### DIFF
--- a/_posts/2024-04-19-1205.md
+++ b/_posts/2024-04-19-1205.md
@@ -495,6 +495,9 @@ All `AbstractBlock` public methods to be overridden were made `protected` and no
 ### Client
 In GUI, setting the initial focus of a screen is now done by overriding `setInitialFocus`, rather than calling it in `init`. `MatrixStack` was replaced with the actual matrix in several rendering code.
 
+#### Rendering
+Some places that previously take `rgb` was updated to take `argb` instead. The new `DyedColorComponent` takes `argb`. Item color providers also take `argb` instead of `rgb`, so make sure to wrap your color with `ColorHelper.Argb.fullAlpha()` or else your item may appear transparent if it is registered to the translucent render layer. Block color providers also `argb` now, but passing `rgb` still works.
+
 ### Other
 DataFixerUpper was updated. This includes several breaking changes, such as `MapCodec` being used in places defining extra fields. Use `RecordCodecBuilder#mapCodec` instead of `create` in this case. Another significant change: `optionalFieldOf` is now strict by default. This means that a decoding error in the field value is now treated as an error, instead of being silently skipped. The `lenientOptionalFieldOf` method restores old behavior.
 


### PR DESCRIPTION
Some places were changed to take `argb` and simply passing `rgb` appears transparent, which can be annoying to debug.