### PR TITLE
Update build workflow

### DIFF
--- a/scripts/src/lib/template/templates/git/workflow.yml
+++ b/scripts/src/lib/template/templates/git/workflow.yml
@@ -18,16 +18,17 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-      - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
       - name: setup jdk ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'microsoft'
-      - name: make gradle wrapper executable
-        run: chmod +x ./gradlew
-      - name: build
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          validate-wrappers: true
+      - name: Build with Gradle
         run: ./gradlew build
       - name: capture build artifacts
         if: ${{ matrix.java == '21' }} # Only upload artifacts built from latest java


### PR DESCRIPTION
Update build workflow to more modern actions. `setup-gradle` is an official gradle workflow replacing `gradle/gradle-build-action` and also validates wrappers.