### PR TITLE
update deprecated wrapper-validation-action

### DIFF
--- a/scripts/src/lib/template/templates/git/workflow.yml
+++ b/scripts/src/lib/template/templates/git/workflow.yml
@@ -19,7 +19,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
       - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v4
       - name: setup jdk ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Hello, I noticed the build via GitHub action fails on my newly setup mod

The reason was gradle/gradle-build-action@v2

As per the [Documentation](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle) gradle/gradle-build-action@v2 has ben deprecated and should be replaced with gradle/actions/setup-gradle@v4

I swapped out the old action for the new one in the template