### PR TITLE
update cli doc page with correct uninstallation command

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -33,7 +33,7 @@ fabric upgrade
 If you wish to remove the Fabric CLI tools run:
 
 <code class="command">
-deno uninstall fabric
+deno uninstall -g fabric
 </code>
 
 ## Usage


### PR DESCRIPTION
without the -g flag, it creates a deno.json in the current directory and fails to uninstall it as it doesn't find the package in the working directory - adding the -g flag uninstalls it globally, as it was installed.