### PR TITLE
Add a Loom property to gradle.properties

### DIFF
--- a/scripts/src/lib/Versions.svelte
+++ b/scripts/src/lib/Versions.svelte
@@ -49,6 +49,7 @@
 minecraft_version={minecraftVersion}
 yarn_mappings={yarnVersion}
 loader_version={loaderVersion}
+loom_version=1.10-SNAPSHOT
 
 # Fabric API
 fabric_version={apiVersion}

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.10-SNAPSHOT'
+	id 'fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 	<%_ if (it.kotlin) { %>
 	id "org.jetbrains.kotlin.jvm" version "<%= it.kotlin.kotlinVersion %>"

--- a/scripts/src/lib/template/templates/gradle/groovy/gradle.properties.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/gradle.properties.eta
@@ -7,6 +7,7 @@ org.gradle.parallel=true
 minecraft_version=<%= it.minecraftVersion %>
 <% if (!it.mojmap) { %>yarn_mappings=<%= it.yarnVersion %>
 <% } %>loader_version=<%= it.loaderVersion %>
+loom_version=1.10-SNAPSHOT
 <% if (it.kotlin) { %>fabric_kotlin_version=<%= it.kotlin.fabricKotlinAdapterVersion %>
 <% } %>
 # Mod Properties


### PR DESCRIPTION
This PR adds a `loom_version` property to `gradle.properties` that is used in the `plugins` block. This puts the Loom version in a more centralised place for easier accessibility.

Ported from [FabricMC/fabric-example-mod#307](https://github.com/FabricMC/fabric-example-mod/pull/307).