### PR TITLE
Cache gradle builds to speed up github actions template

### DIFF
--- a/scripts/src/lib/template/templates/git/workflow.yml
+++ b/scripts/src/lib/template/templates/git/workflow.yml
@@ -12,13 +12,22 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: setup jdk
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'microsoft'
+      - name: setup cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .gradle/
+            build/
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build


### PR DESCRIPTION
This PR enables caching to speed up builds on github actions.

My [ReplaceBlocksMod](https://github.com/adil192/ReplaceBlocksMod)'s builds went down from around 2 minutes to 1 minute, and [ForgetMeStick](https://github.com/adil192/ForgetMeStick)'s from 1-2 minutes to <1 minute. These mods are quite small and bigger projects will have greater speedups.

Note that the `gradle/actions/setup-gradle@v4` action also validates the gradle wrapper like before, so the behaviour should be identical besides the added caching