### PR TITLE
add global env var for package prefix in cli template generator

### DIFF
--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -219,7 +219,7 @@ async function promptUser(
 
   const packageName: string = cli.packageName ?? await Input.prompt({
     message: "Choose a package name",
-    default: generator.formatPackageName(Deno.env.get("FABRIC_MOD_GENERATOR_GLOBAL_PACKAGE_PREFIX") ?? modId),
+    default: generator.formatPackageName((Deno.env.get("FABRIC_MOD_GENERATOR_GLOBAL_PACKAGE_PREFIX") ?? "") + modId),
     transform: (value) => {
       return generator.formatPackageName(value);
     },

--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -219,7 +219,7 @@ async function promptUser(
 
   const packageName: string = cli.packageName ?? await Input.prompt({
     message: "Choose a package name",
-    default: generator.formatPackageName(modId),
+    default: generator.formatPackageName(Deno.env.get("FABRIC_MOD_GENERATOR_GLOBAL_PACKAGE_PREFIX") ?? "" + modId),
     transform: (value) => {
       return generator.formatPackageName(value);
     },

--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -219,7 +219,7 @@ async function promptUser(
 
   const packageName: string = cli.packageName ?? await Input.prompt({
     message: "Choose a package name",
-    default: generator.formatPackageName(Deno.env.get("FABRIC_MOD_GENERATOR_GLOBAL_PACKAGE_PREFIX") ?? "" + modId),
+    default: generator.formatPackageName(Deno.env.get("FABRIC_MOD_GENERATOR_GLOBAL_PACKAGE_PREFIX") ?? modId),
     transform: (value) => {
       return generator.formatPackageName(value);
     },


### PR DESCRIPTION
I'm sure I didn't do this right, but I'd like an option to specify a shellwide option for package prefix. 