### PR TITLE
Mention onStateReplaced changing

### DIFF
--- a/_posts/2025-03-24-1215.md
+++ b/_posts/2025-03-24-1215.md
@@ -144,3 +144,4 @@ In Minecraft [25w03a](https://www.minecraft.net/en-us/article/minecraft-snapshot
 
 ### Miscellaneous
 - `DataPool` has been replaced with `Pool`.
+- `AbstractBlock#onStateReplaced` has been significantly changed, the state provided is the old state and it now runs after block entities get removed. Block entities should use `BlockEntity#onBlockReplaced` instead.


### PR DESCRIPTION
Looks like everything that used it to, for example, drop extra items from a block entity, have switched to the method in BlockEntity.
See `CampfireBlock#onStateReplaced` in 1.21.4 compared to `CampfireBlockEntity#onBlockReplaced` in 1.21.5 as an example.