### PR TITLE
Add libs.versions.toml alternative tab for /develop

### DIFF
--- a/scripts/src/lib/CodeBlock.svelte
+++ b/scripts/src/lib/CodeBlock.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { type CodeBlock } from "./CodeBlock";
+
+	export let codeBlock: CodeBlock;
+	const timeoutMs = 2500;
+	let copied = false;
+	let timeout: ReturnType<typeof setTimeout>;
+
+	function copyToClipboard(text: string) {
+		navigator.clipboard.writeText(text).then(() => {
+			copied = true;
+			clearTimeout(timeout);
+			timeout = setTimeout(() => {
+				copied = false;
+			}, timeoutMs);
+		});
+	}
+</script>
+
+<div class="code-container">
+	<button
+		class:copied
+		class="copy-button"
+		on:click={() => copyToClipboard(codeBlock.code)}
+		>{copied ? "COPIED ✔" : "COPY"}
+	</button>
+	<pre><code>{codeBlock.code}</code></pre>
+</div>
+
+<style>
+	.code-container {
+		position: relative;
+	}
+
+	.copy-button {
+		position: absolute;
+		top: 0.4rem;
+		right: 0.4rem;
+		background-color: #22262b;
+		border: 1px solid #555;
+		border-radius: 4px;
+		font-size: 0.8rem;
+		padding: 0.2rem 0.5rem;
+		cursor: pointer;
+		transition: background-color 0.2s ease;
+		z-index: 10;
+	}
+
+	.copy-button:hover {
+		background-color: #2d3136;
+	}
+	.copy-button.copied {
+		background-color: #3b3;
+	}
+</style>

--- a/scripts/src/lib/CodeBlock.ts
+++ b/scripts/src/lib/CodeBlock.ts
@@ -1,0 +1,9 @@
+export interface CodeTab {
+	label: string;
+	codeBlock: CodeBlock;
+}
+
+export interface CodeBlock {
+	language: string;
+	code: string;
+}

--- a/scripts/src/lib/CodeTabs.svelte
+++ b/scripts/src/lib/CodeTabs.svelte
@@ -1,0 +1,69 @@
+<!-- CodeTabs.svelte -->
+<script lang="ts">
+	import { createEventDispatcher } from "svelte";
+	import type { CodeTab } from "./CodeBlock";
+	import CodeBlock from "./CodeBlock.svelte";
+	export let tabs: CodeTab[];
+	export let selectedTab: string;
+
+	const dispatch = createEventDispatcher<{ selectedTab: string }>();
+
+	function selectTab(tab: string) {
+		selectedTab = tab;
+		dispatch("selectedTab", tab);
+	}
+</script>
+
+<div class="code-tabs">
+	<div class="tab-buttons">
+		{#each tabs as tab}
+			<button
+				class:selected={tab.label === selectedTab}
+				on:click={() => selectTab(tab.label)}
+				type="button"
+			>
+				<span class="tab-label">{tab.label}</span>
+			</button>
+		{/each}
+	</div>
+
+	<div class="tab-content">
+		{#each tabs as tab}
+			{#if tab.label === selectedTab}
+				<CodeBlock codeBlock={tab.codeBlock} />
+			{/if}
+		{/each}
+	</div>
+</div>
+
+<style>
+	.tab-buttons {
+		display: flex;
+		margin-bottom: 1px;
+	}
+	.tab-buttons button {
+		padding: 0.25em 1em;
+		margin-right: 0.25em;
+		cursor: pointer;
+		background: #22262b;
+		transition: background-color 0.2s ease;
+		border: none;
+		border-radius: 4px 4px 0 0;
+		font-family: monospace;
+	}
+	.tab-buttons button:hover {
+		background-color: #2d3136;
+	}
+	.tab-buttons button > span.tab-label {
+		color: #bbb;
+	}
+	.tab-buttons button.selected {
+		background: #55595e;
+	}
+	.tab-buttons button.selected > span.tab-label {
+		color: #fff;
+	}
+	.tab-content {
+		position: relative;
+	}
+</style>

--- a/scripts/src/lib/Versions.svelte
+++ b/scripts/src/lib/Versions.svelte
@@ -1,40 +1,107 @@
 <script lang="ts">
- import {
+    import { onMount } from "svelte";
+    import {
         getGameVersions,
         getYarnVersions,
         getLoaderVersions,
         getApiVersions,
-        isApiVersionvalidForMcVersion
+        isApiVersionvalidForMcVersion,
+        type YarnVersion,
+        type LoaderVersion,
     } from "./Api";
+    import CodeTabs from "./CodeTabs.svelte";
+    import type { CodeTab } from "./CodeBlock";
+    import CodeBlock from "./CodeBlock.svelte";
 
+    let gameVersions: string[] = [];
+    let yarnVersions: YarnVersion[] = [];
+    let loaderVersions: LoaderVersion[] = [];
+    let apiVersions: string[] = [];
+
+    const loomVersion = "1.10-SNAPSHOT";
     let minecraftVersion: string | undefined;
-    let yarnVersion: string;
-    let loaderVersion: string;
-    let apiVersion: string;
+    let yarnVersion: string | undefined;
+    let loaderVersion: string | undefined;
+    let apiVersion: string | undefined;
 
-    let gameVersions = getGameVersions().then((versions) => {
-        minecraftVersion = versions.find((v) => v.stable)!.version
-        const latestVersion = versions[0];
-        return versions.filter((v) => v.stable || v == latestVersion).map((v) => v.version);
+    const tabs: CodeTab[] = [
+        {
+            label: "gradle.properties",
+            codeBlock: {
+                language: "properties",
+                code: "", // Will be filled in when the API calls return
+            },
+        },
+        {
+            label: "libs.versions.toml",
+            codeBlock: {
+                language: "toml",
+                code: "",
+            },
+        },
+    ];
+    let selectedTab = tabs[0].label;
+
+    onMount(async () => {
+        [gameVersions, loaderVersions, yarnVersions, apiVersions] =
+            await Promise.all([
+                getGameVersions().then((versions) => {
+                    minecraftVersion = versions.find((v) => v.stable)!.version;
+                    const latestVersion = versions[0];
+                    return versions
+                        .filter((v) => v.stable || v == latestVersion)
+                        .map((v) => v.version);
+                }),
+                getLoaderVersions().then((versions) => {
+                    loaderVersion = versions.find((v) => v.stable)!.version;
+                    return versions;
+                }),
+                getYarnVersions(),
+                getApiVersions(),
+            ]);
     });
 
-    const loaderVersions = getLoaderVersions().then((versions) => {
-        loaderVersion = versions.find((v) => v.stable)!.version
-        return versions;
-    });
+    $: if (minecraftVersion && yarnVersions.length) {
+        yarnVersion =
+            yarnVersions.find((v) => v.gameVersion == minecraftVersion)
+                ?.version || "unknown";
+    }
+    $: if (minecraftVersion && apiVersions.length) {
+        apiVersion = apiVersions
+            .filter((v) => isApiVersionvalidForMcVersion(v, minecraftVersion))
+            .pop()!;
+    }
 
-    const yarnVersions = getYarnVersions()
-    const apiVersions = getApiVersions();
+    $: if (minecraftVersion && apiVersion && yarnVersion && loaderVersion) {
+        tabs[0].codeBlock.code = `
+minecraft_version=${minecraftVersion}
+yarn_mappings=${yarnVersion}
+loader_version=${loaderVersion}
+loom_version=${loomVersion}
 
-    $: yarnVersions.then(versions => yarnVersion = versions.find(v => v.gameVersion == minecraftVersion)?.version || "unknown")
-    $: apiVersions.then(versions => apiVersion = versions.filter(v => isApiVersionvalidForMcVersion(v, minecraftVersion)).pop()!)
+# Fabric API
+fabric_version=${apiVersion}
+`.trim();
+        tabs[1].codeBlock.code = `
+minecraft_version = "${minecraftVersion}"
+yarn_mappings = "${yarnVersion}"
+loader_version = "${loaderVersion}"
+loom_version = "${loomVersion}"
+
+# Fabric API
+fabric_version = "${apiVersion}"
+`.trim();
+    }
 </script>
 
 {#await gameVersions}
     <p>Loading versions...</p>
 {:then gameVersions}
-		<h2>Latest Versions</h2>
-		<p>Select a Minecraft version to get the recommended versions of Fabric Loader, Yarn, and Fabric API for your <code>gradle.properties</code> file.</p>
+    <h2>Latest Versions</h2>
+    <p>
+        Select a Minecraft version to get the recommended versions of Fabric
+        Loader, Yarn, and Fabric API for your <code>{selectedTab}</code> file.
+    </p>
     <p>
         Minecraft Version:
         <select bind:value={minecraftVersion} style="min-width: 200px">
@@ -44,32 +111,43 @@
         </select>
     </p>
 
-    <div style="margin-bottom: 15px;">
-        <pre><code>
-minecraft_version={minecraftVersion}
-yarn_mappings={yarnVersion}
-loader_version={loaderVersion}
-loom_version=1.10-SNAPSHOT
+    <CodeTabs {tabs} bind:selectedTab />
 
-# Fabric API
-fabric_version={apiVersion}
-        </code></pre>
+    <p>
+        <strong>Important Note:</strong> In some cases, such as snapshots or special
+        releases, the Fabric API version might not align perfectly with your Minecraft
+        version.
+    </p>
+    <p>
+        If you encounter issues, double-check the latest release of Fabric API
+        on <a href="https://modrinth.com/mod/fabric-api/versions">Modrinth</a>
+        or
+        <a href="https://www.curseforge.com/minecraft/mc-mods/fabric-api/files"
+            >CurseForge</a
+        >.
+    </p>
 
-				<p><strong>Important Note:</strong> In some cases, such as snapshots or special releases, the <code>fabric-api</code> version might not align perfectly with your Minecraft version.</p>
-				<p>If you encounter issues, double-check the latest release of Fabric API on <a href="https://modrinth.com/mod/fabric-api">Modrinth</a> or <a href="https://minecraft.curseforge.com/projects/fabric/files">CurseForge</a>.</p> 
-      </div>
-			
-			<hr />
+    <hr />
 
-      <h2>Automatically Update Mappings</h2>
-			<p>Keep your project up-to-date with the correct Yarn mappings using this automatic update command:</p>
+    <h2>Automatically Update Mappings</h2>
+    <p>
+        Keep your project up-to-date with the correct Yarn mappings using this
+        automatic update command:
+    </p>
 
-			<code class="copy-code">
-				gradlew migrateMappings --mappings "{yarnVersion}"
-			</code>
+    <CodeBlock
+        codeBlock={{
+            language: "bash",
+            code: `gradlew migrateMappings --mappings "${yarnVersion}"`,
+        }}
+    />
 
-			<p>For more information on this command, you should refer to the <a href="https://fabricmc.net/wiki/tutorial:migratemappings">Updating Yarn Mappings</a> wiki page.</p>
-
+    <p>
+        For more information on this command, you should refer to the <a
+            href="https://fabricmc.net/wiki/tutorial:migratemappings"
+            >Updating Yarn Mappings</a
+        > wiki page.
+    </p>
 {:catch error}
     <p style="color: red">Error: {error.message}</p>
     <p>
@@ -83,15 +161,7 @@ fabric_version={apiVersion}
 
 <h2>Loom</h2>
 
-<p>The recommended loom version is <strong>1.10-SNAPSHOT</strong>. This is usually defined near the top of your build.gradle file.</p>
-
-<style>
-    .copy-code {
-      display: inline-block;
-      width: 100%;
-      overflow-x: auto;
-      overflow-y: hidden;
-      white-space: nowrap;
-      user-select: all;
-    }
-  </style>
+<p>
+    The recommended loom version is <code>{loomVersion}</code>. This is usually
+    defined near the top of your <code>build.gradle</code> file.
+</p>

--- a/scripts/src/lib/Versions.svelte
+++ b/scripts/src/lib/Versions.svelte
@@ -100,7 +100,7 @@ fabric_version = "${apiVersion}"
     <h2>Latest Versions</h2>
     <p>
         Select a Minecraft version to get the recommended versions of Fabric
-        Loader, Yarn, and Fabric API for your <code>{selectedTab}</code> file.
+        Loader, Yarn, Loom and Fabric API to use in your project.
     </p>
     <p>
         Minecraft Version:


### PR DESCRIPTION
Added 2 svelte components: `CodeBlock` and `CodeTabs`.
`CodeBlock` is for displaying code with a little copy button on top right.
`CodeTabs` is the main part with tabs to change between different languages.

A few other changes that aren't directly related to the tabs:
- Updated the Curseforge link
- Changed the Modrinth link to match the Curseforge one in the way that it directly links to the version list rather than the mod page
- Refactored the loom version into a variable so it can all be set from one place

Note that this is my first time with Svelte, and I'm not very good at web dev either. There might be things I didn't account for.
