### PR TITLE
Fix broken diff view in 1.21.6 post

### DIFF
--- a/_posts/2025-06-15-1216.md
+++ b/_posts/2025-06-15-1216.md
@@ -33,7 +33,7 @@ In addition to being relocated, the `BlockRenderLayerMap` API was also updated t
 ```diff
 - import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 + import net.fabricmc.fabric.api.client.rendering.v1.BlockRenderLayerMap;
-//...
+ ...
 - BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.MY_EPIC_BLOCK, BlockRenderLayer.CUTOUT)
 + BlockRenderLayerMap.putBlock(ModBlocks.MY_EPIC_BLOCK, BlockRenderLayer.CUTOUT)
 ```


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e43e87ac-e576-48ad-a095-f64f8ace4d52)
After:
![image](https://github.com/user-attachments/assets/53c15e7c-48b9-43c0-bc0b-732726633003)
