### PR TITLE
Mod template: require annotations by default on mixin overwrites

### DIFF
--- a/scripts/src/lib/template/mixin.ts
+++ b/scripts/src/lib/template/mixin.ts
@@ -21,6 +21,9 @@ export async function generateMixin(writer: TemplateWriter, options: ComputedCon
         ],
         "injectors": {
             "defaultRequire": 1
+        },
+        "overwrites": {
+            "requireAnnotations": true
         }
     };
 


### PR DESCRIPTION
This causes mixin to throw an error when you accidentally overwrite a vanilla method