### PR TITLE
Fix GDLauncher page link

### DIFF
--- a/_layouts/use.html
+++ b/_layouts/use.html
@@ -44,7 +44,7 @@ layout: page
             </a>
         </li>
         <li>
-            <a href="https://gdevs.io/">
+            <a href="https://gdlauncher.com/">
                 GDLauncher
             </a>
         </li>


### PR DESCRIPTION
The GDLauncher home page moved from `gdevs.io` to `gdlauncher.com`. This just fixes the link on the fabric page to point to the new site.