### PR TITLE
Use setup-gradle

### DIFF
--- a/scripts/src/lib/template/templates/git/workflow.yml
+++ b/scripts/src/lib/template/templates/git/workflow.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
       - name: setup jdk
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'microsoft'
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v5
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build


### PR DESCRIPTION
setup-gradle adds persistent gradle cache for faster CI builds, build summary and does wrapper validation as part of its lifecycle. https://github.com/gradle/actions?tab=readme-ov-file#the-wrapper-validation-action