### PR TITLE
Fix issue where package name sanitazation would only fix the first violation

### DIFF
--- a/scripts/src/lib/template/minecraft.ts
+++ b/scripts/src/lib/template/minecraft.ts
@@ -90,7 +90,7 @@ export function computeCustomModIdErrors(id: string | undefined): string[] | und
 }
 
 export function formatPackageName(packageName: string): string {
-	return packageName.toLocaleLowerCase().replace(/\s+/g, '.').replace(/[^a-za-z0-9_\.]/, "")
+	return packageName.toLocaleLowerCase().replaceAll(/\s+/g, '.').replaceAll(/[^a-za-z0-9_\.]/, "")
 }
 
 export function nameToModId(name: string) {


### PR DESCRIPTION
Before the name `my-test-mod` would not turn into `mytestmod` but into `mytest-mod`, which is an invalid package name. Now all of these occurrences will be fixed. It could also be interesting to treat hyphens the same as whitespace and turn it into `my.test.mod` instead, but I did not do that.