### PR TITLE
Update Java version from 21 to 25 in workflow

### DIFF
--- a/scripts/src/lib/template/templates/git/workflow.yml
+++ b/scripts/src/lib/template/templates/git/workflow.yml
@@ -17,7 +17,7 @@ jobs:
       - name: setup jdk
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'microsoft'
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew


### PR DESCRIPTION
26.1 snapshots require Java 25, so I have updated the template workflow accordingly.

Is this something that is usually not updated until release?

Closes #152