### PR TITLE
Enable Gradle caching for faster builds

### DIFF
--- a/scripts/src/lib/template/templates/gradle/groovy/gradle.properties.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/gradle.properties.eta
@@ -1,5 +1,8 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
+
+# Done to speedup the build process.
+org.gradle.caching=true
 org.gradle.parallel=true
 
 # IntelliJ IDEA is not yet fully compatible with configuration cache, see: https://github.com/FabricMC/fabric-loom/issues/1349


### PR DESCRIPTION
Added caching option to improve build speed.

The title and the description above (^) are auto filled by github, didn't change as it was explanatory enough for the commit message itself - but i'll provide more explanation below for the pr description:

Was suprised this was turned off by default when I started over my fabric mod project a while ago.

I thought it was intentional that this gradle.properties from fabric template didn't have it; because i assumed caching was enabled by default - apparently build cache is still disabled by default even in the latest gradle 9.4.0-rc1 version? It's listed under best practices for performance: https://docs.gradle.org/9.4.0-rc-1/userguide/best_practices_performance.html#use_build_cache

Decided to make this pr to add flag to enable it as I thought it was a worthwhile thing to upstream so that other modders start with it enabled instead of having to discover it themselves.

I've also seperated the jvmargs from the caching and parallel section - as the comment of increasing memory available to gradle was kind of misleading with enabling parallel flag.

I haven't noticed any failures or regressions from this, but feel free to close this if it's specifically incompatible with the way loom or anything else in the stack operates that I don't know of. I'm aware of the comment below where IntelliJ has an issue with configuration cache, but configuration cache feature is way newer, from what  I know build cache exists since early days of gradle to the point where it might as well be default enabled by now. The same best practices document linked above has a note for configuration cache saying tome tools might be incompatible whilst still saying it is the recommended mode of execution but disabled default - while it makes no such "tools might be incompatible" note for the build cache, so I think this should be fine after all.

Even if something is incompatible and it's preferred that build cache stays disabled - a line explicitly assigning it the default false value with a comment just like how it's done for configuration cache might be desired.