### PR TITLE
Set project name instead of artifact name

### DIFF
--- a/scripts/src/lib/template/gradle.ts
+++ b/scripts/src/lib/template/gradle.ts
@@ -13,3 +13,7 @@ export async function addGradle(writer: TemplateWriter, config: ComputedConfigur
 		await addGroovyGradle(writer, config);
 	}
 }
+
+export function toProjectName(modid: string): string {
+	return modid.replaceAll('_', '-');
+}

--- a/scripts/src/lib/template/gradlegroovy.ts
+++ b/scripts/src/lib/template/gradlegroovy.ts
@@ -2,10 +2,10 @@ import type { ComputedConfiguration, TemplateWriter } from './template';
 import { renderTemplate } from './eta';
 
 import buildGradleTemplate from './templates/gradle/groovy/build.gradle.eta?raw';
-import settingsGradle from './templates/gradle/groovy/settings.gradle?raw';
+import settingsGradleTemplate from './templates/gradle/groovy/settings.gradle.eta?raw';
 import { getJavaVersion } from './java';
 
 export async function addGroovyGradle(writer: TemplateWriter, config: ComputedConfiguration) {
 	await writer.write('build.gradle', renderTemplate(buildGradleTemplate, {...config, java: getJavaVersion(config.minecraftVersion)}));
-	await writer.write('settings.gradle', settingsGradle);
+	await writer.write('settings.gradle', renderTemplate(settingsGradleTemplate, config));
 }

--- a/scripts/src/lib/template/template.ts
+++ b/scripts/src/lib/template/template.ts
@@ -41,6 +41,7 @@ export interface KotlinConfiguration {
 // Computed options are not presented to the user.
 export interface ComputedConfiguration extends Configuration {
 	modid: string,
+	projectName: string,
 	loaderVersion: string,
 	fabricVersion: string,
 	yarnVersion: string | undefined,
@@ -111,6 +112,7 @@ async function computeConfig(options: Configuration): Promise<ComputedConfigurat
 	const unobfuscated = minecraftIsUnobfuscated(options.minecraftVersion);
 	return {
 		...options,
+		projectName: options.modid.replaceAll('_', '-'),
 		loaderVersion: (await getLoaderVersions()).find((v) => v.stable)!.version,
 		fabricVersion: await getApiVersionForMinecraft(options.minecraftVersion),
 		yarnVersion: unobfuscated ? undefined : (await getMinecraftYarnVersions(options.minecraftVersion))[0].version,

--- a/scripts/src/lib/template/template.ts
+++ b/scripts/src/lib/template/template.ts
@@ -41,7 +41,6 @@ export interface KotlinConfiguration {
 // Computed options are not presented to the user.
 export interface ComputedConfiguration extends Configuration {
 	modid: string,
-	projectName: string,
 	loaderVersion: string,
 	fabricVersion: string,
 	yarnVersion: string | undefined,
@@ -112,7 +111,6 @@ async function computeConfig(options: Configuration): Promise<ComputedConfigurat
 	const unobfuscated = minecraftIsUnobfuscated(options.minecraftVersion);
 	return {
 		...options,
-		projectName: toProjectName(options.modid),
 		loaderVersion: (await getLoaderVersions()).find((v) => v.stable)!.version,
 		fabricVersion: await getApiVersionForMinecraft(options.minecraftVersion),
 		yarnVersion: unobfuscated ? undefined : (await getMinecraftYarnVersions(options.minecraftVersion))[0].version,

--- a/scripts/src/lib/template/template.ts
+++ b/scripts/src/lib/template/template.ts
@@ -1,4 +1,4 @@
-import { addGradle } from './gradle';
+import { addGradle, toProjectName } from './gradle';
 import { addGradleWrapper } from './gradlewrapper';
 import { getApiVersionForMinecraft, getKotlinAdapterVersions, getLoaderVersions, getMinecraftYarnVersions, type GameVersion, getGameVersions } from '../Api';
 import { addModJson } from './modjson';
@@ -112,7 +112,7 @@ async function computeConfig(options: Configuration): Promise<ComputedConfigurat
 	const unobfuscated = minecraftIsUnobfuscated(options.minecraftVersion);
 	return {
 		...options,
-		projectName: options.modid.replaceAll('_', '-'),
+		projectName: toProjectName(options.modid),
 		loaderVersion: (await getLoaderVersions()).find((v) => v.stable)!.version,
 		fabricVersion: await getApiVersionForMinecraft(options.minecraftVersion),
 		yarnVersion: unobfuscated ? undefined : (await getMinecraftYarnVersions(options.minecraftVersion))[0].version,

--- a/scripts/src/lib/template/templates/gradle/gradle.properties.eta
+++ b/scripts/src/lib/template/templates/gradle/gradle.properties.eta
@@ -16,7 +16,6 @@ loom_version=1.15-SNAPSHOT
 # Mod Properties
 mod_version=1.0.0
 maven_group=<%= it.packageName %>
-archives_base_name=<%= it.modid %>
 
 # Dependencies
 fabric_api_version=<%= it.fabricVersion %>

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -11,10 +11,6 @@
 version = project.mod_version
 group = project.maven_group
 
-base {
-	archivesName = project.archives_base_name
-}
-
 repositories {
 	// Add repositories to retrieve artifacts from in here.
 	// You should only use this when depending on other mods because
@@ -81,10 +77,10 @@ java {
 }
 
 jar {
-	inputs.property "archivesName", project.base.archivesName
+	inputs.property "project.name", project.name
 
 	from("LICENSE") {
-		rename { "${it}_${inputs.properties.archivesName}"}
+		rename { "${it}_${project.name}"}
 	}
 }
 
@@ -92,7 +88,6 @@ jar {
 publishing {
 	publications {
 		create("mavenJava", MavenPublication) {
-			artifactId = project.archives_base_name
 			from components.java
 		}
 	}

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -77,7 +77,7 @@ java {
 }
 
 jar {
-	inputs.property "project.name", project.name
+	inputs.property "projectName", project.name
 
 	from("LICENSE") {
 		rename { "${it}_${project.name}"}

--- a/scripts/src/lib/template/templates/gradle/groovy/settings.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/settings.gradle.eta
@@ -8,3 +8,6 @@ pluginManagement {
 		gradlePluginPortal()
 	}
 }
+
+// Should match your modid, but with _ converted to -
+rootProject.name = '<%= it.modid %>'

--- a/scripts/src/lib/template/templates/gradle/groovy/settings.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/settings.gradle.eta
@@ -10,4 +10,4 @@ pluginManagement {
 }
 
 // Should match your modid, but with _ converted to -
-rootProject.name = '<%= it.modid %>'
+rootProject.name = '<%= it.projectName %>'

--- a/scripts/src/lib/template/templates/gradle/groovy/settings.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/settings.gradle.eta
@@ -9,5 +9,5 @@ pluginManagement {
 	}
 }
 
-// Should match your modid, but with _ converted to -
+// Should match your modid
 rootProject.name = '<%= it.modid %>'

--- a/scripts/src/lib/template/templates/gradle/groovy/settings.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/settings.gradle.eta
@@ -10,4 +10,4 @@ pluginManagement {
 }
 
 // Should match your modid, but with _ converted to -
-rootProject.name = '<%= it.projectName %>'
+rootProject.name = '<%= it.modid %>'

--- a/scripts/src/lib/template/templates/gradle/kotlin/build.gradle.kts.eta
+++ b/scripts/src/lib/template/templates/gradle/kotlin/build.gradle.kts.eta
@@ -11,10 +11,6 @@
 version = providers.gradleProperty("mod_version").get()
 group = providers.gradleProperty("maven_group").get()
 
-base {
-	archivesName = providers.gradleProperty("archives_base_name")
-}
-
 repositories {
 	// Add repositories to retrieve artifacts from in here.
 	// You should only use this when depending on other mods because
@@ -80,10 +76,10 @@ java {
 }
 
 tasks.jar {
-	inputs.property("archivesName", base.archivesName)
+	inputs.property("project.name", project.name)
 
 	from("LICENSE") {
-		rename { "${it}_${base.archivesName.get()}" }
+		rename { "${it}_${project.name}" }
 	}
 }
 
@@ -91,7 +87,6 @@ tasks.jar {
 publishing {
 	publications {
 		register<MavenPublication>("mavenJava") {
-			artifactId = base.archivesName.get()
 			from(components["java"])
 		}
 	}

--- a/scripts/src/lib/template/templates/gradle/kotlin/build.gradle.kts.eta
+++ b/scripts/src/lib/template/templates/gradle/kotlin/build.gradle.kts.eta
@@ -76,7 +76,7 @@ java {
 }
 
 tasks.jar {
-	inputs.property("project.name", project.name)
+	inputs.property("projectName", project.name)
 
 	from("LICENSE") {
 		rename { "${it}_${project.name}" }

--- a/scripts/src/lib/template/templates/gradle/kotlin/settings.gradle.kts.eta
+++ b/scripts/src/lib/template/templates/gradle/kotlin/settings.gradle.kts.eta
@@ -12,3 +12,6 @@ pluginManagement {
 		id("<% if (it.unobfuscated) { %>net.fabricmc.fabric-loom<% } else { %>net.fabricmc.fabric-loom-remap<% } %>") version providers.gradleProperty("loom_version")
 	}
 }
+
+// Should match your modid, but with _ converted to -
+rootProject.name = "<%= it.modid %>"

--- a/scripts/src/lib/template/templates/gradle/kotlin/settings.gradle.kts.eta
+++ b/scripts/src/lib/template/templates/gradle/kotlin/settings.gradle.kts.eta
@@ -13,5 +13,5 @@ pluginManagement {
 	}
 }
 
-// Should match your modid, but with _ converted to -
+// Should match your modid
 rootProject.name = "<%= it.modid %>"

--- a/scripts/src/lib/template/templates/gradle/kotlin/settings.gradle.kts.eta
+++ b/scripts/src/lib/template/templates/gradle/kotlin/settings.gradle.kts.eta
@@ -14,4 +14,4 @@ pluginManagement {
 }
 
 // Should match your modid, but with _ converted to -
-rootProject.name = "<%= it.projectName %>"
+rootProject.name = "<%= it.modid %>"

--- a/scripts/src/lib/template/templates/gradle/kotlin/settings.gradle.kts.eta
+++ b/scripts/src/lib/template/templates/gradle/kotlin/settings.gradle.kts.eta
@@ -14,4 +14,4 @@ pluginManagement {
 }
 
 // Should match your modid, but with _ converted to -
-rootProject.name = "<%= it.modid %>"
+rootProject.name = "<%= it.projectName %>"


### PR DESCRIPTION
Instead of setting the archive name, this sets the root project name. The project name is then used for the artifact id and archive name by default.

Depends on #156