### PR TITLE
Fix package name with multiple invalid characters

### DIFF
--- a/scripts/src/lib/template/minecraft.ts
+++ b/scripts/src/lib/template/minecraft.ts
@@ -94,7 +94,7 @@ export function computeCustomModIdErrors(id: string | undefined): string[] | und
 }
 
 export function formatPackageName(packageName: string): string {
-	return packageName.toLocaleLowerCase().replace(/\s+/g, '.').replace(/[^a-za-z0-9_\.]/, "")
+	return packageName.toLocaleLowerCase().replaceAll(/\s+/g, '.').replaceAll(/[^a-za-z0-9_\.]/g, "")
 }
 
 export function nameToModId(name: string) {


### PR DESCRIPTION
Fixes the automatically generated package name when multiple characters in the mod id or global prefix are invalid.