### PR TITLE
fix(cli): command name in shell Command

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -15,7 +15,7 @@ const VERSION = typeof __VERSION__ !== "undefined" ? __VERSION__ : "dev";
 
 if (import.meta.main) {
   const cmd = new Command()
-    .name("Fabric CLI tools")
+    .name("fabric")
     .version(VERSION)
     .description("A set of command line tools to aid Fabric mod development")
     .action(() => {


### PR DESCRIPTION
command name is supposed to be the program thats running, e.g. `fabric`

other shells ignore somehow but fish breaks