### PR TITLE
Provide a proper error for missing Fabric API

### DIFF
--- a/scripts/src/lib/Api.ts
+++ b/scripts/src/lib/Api.ts
@@ -83,7 +83,13 @@ export function getKotlinAdapterVersions(): Promise<string[]> {
 
 export async function getApiVersionForMinecraft(minecraftVersion: string): Promise<string> {
     const apiVersions = await getApiVersions();
-    return apiVersions.filter(v => isApiVersionvalidForMcVersion(v, minecraftVersion)).pop()!;
+    const resolvedVersion = apiVersions.filter(v => isApiVersionvalidForMcVersion(v, minecraftVersion)).pop();
+
+    if(!resolvedVersion) {
+        throw new Error(`Could not find a valid Fabric API version for Minecraft ${minecraftVersion}`);
+    }
+
+    return resolvedVersion;
 }
 
 function getMajorMinecraftVersion(minecraftVersion: string): number {


### PR DESCRIPTION
Prevents weird `undefined`-related messages when there is no fabric api available for a given minecraft version.