### PR TITLE
Bump actions in template CI workflow

### DIFF
--- a/scripts/src/lib/template/templates/git/workflow.yml
+++ b/scripts/src/lib/template/templates/git/workflow.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
       - name: setup jdk
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'microsoft'
@@ -24,7 +24,7 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Artifacts
           path: build/libs/


### PR DESCRIPTION
This bumps all actions in the template `build.yml` CI workflow to latest, and prevents the Node 20 deprecation warning.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/