### PR TITLE
Automatically deploy to example mod

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,9 @@
+# Fabric Example Mod
+
+## Setup
+
+For setup instructions please see the [fabric documentation page](https://docs.fabricmc.net/develop/getting-started/setting-up) that relates to the IDE that you are using.
+
+## License
+
+This template is available under the CC0 license. Feel free to learn from it and incorporate it in your own projects.

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,9 +1,0 @@
-# Fabric Example Mod
-
-## Setup
-
-For setup instructions please see the [fabric documentation page](https://docs.fabricmc.net/develop/getting-started/setting-up) that relates to the IDE that you are using.
-
-## License
-
-This template is available under the CC0 license. Feel free to learn from it and incorporate it in your own projects.

--- a/.github/scripts/template-versions.ts
+++ b/.github/scripts/template-versions.ts
@@ -1,0 +1,12 @@
+import { getGameVersions, getMajorMinecraftVersion, getMinorMinecraftVersion } from '../../scripts/dist/fabric-template-generator.js';
+import { setOutput } from 'npm:@actions/core';
+
+const stableVersions = (await getGameVersions()).filter(x => x.stable);
+const latestVersions = stableVersions.reduce((acc, x) => {
+    const major = getMajorMinecraftVersion(x.version);
+    const minor = getMinorMinecraftVersion(x.version);
+    acc[`${major}.${minor}`] ??= x.version;
+    return acc;
+}, {});
+
+setOutput('result', latestVersions);

--- a/.github/scripts/template-versions.ts
+++ b/.github/scripts/template-versions.ts
@@ -1,12 +1,14 @@
+// @deno-types="../../scripts/dist/fabric-template-generator.d.ts"
 import { getGameVersions, getMajorMinecraftVersion, getMinorMinecraftVersion } from '../../scripts/dist/fabric-template-generator.js';
-import { setOutput } from 'npm:@actions/core';
 
 const stableVersions = (await getGameVersions()).filter(x => x.stable);
-const latestVersions = stableVersions.reduce((acc, x) => {
+
+const latestVersions = stableVersions.reduce((acc: Record<string, string>, x) => {
     const major = getMajorMinecraftVersion(x.version);
     const minor = getMinorMinecraftVersion(x.version);
     acc[`${major}.${minor}`] ??= x.version;
     return acc;
 }, {});
 
-setOutput('result', latestVersions);
+const result = Object.entries(latestVersions).map(([branch, version]) => ({ branch, version }));
+console.log(JSON.stringify(result));

--- a/.github/scripts/template-versions.ts
+++ b/.github/scripts/template-versions.ts
@@ -1,14 +1,7 @@
 // @deno-types="../../scripts/dist/fabric-template-generator.d.ts"
-import { getTemplateGameVersions, getMajorMinecraftVersion, getMinorMinecraftVersion } from '../../scripts/dist/fabric-template-generator.js';
+import { getTemplateGameVersions } from '../../scripts/dist/fabric-template-generator.js';
 
 const stableVersions = (await getTemplateGameVersions()).filter(x => x.stable);
 
-const latestVersions = stableVersions.reduce((acc: Record<string, string>, x) => {
-    const major = getMajorMinecraftVersion(x.version);
-    const minor = getMinorMinecraftVersion(x.version);
-    acc[`${major}.${minor}`] ??= x.version;
-    return acc;
-}, {});
-
-const result = Object.entries(latestVersions).map(([branch, version]) => ({ branch, version }));
+const result = stableVersions.map(({version}) => ({ branch: version, version }));
 console.log(JSON.stringify(result));

--- a/.github/scripts/template-versions.ts
+++ b/.github/scripts/template-versions.ts
@@ -1,7 +1,7 @@
 // @deno-types="../../scripts/dist/fabric-template-generator.d.ts"
-import { getGameVersions, getMajorMinecraftVersion, getMinorMinecraftVersion } from '../../scripts/dist/fabric-template-generator.js';
+import { getTemplateGameVersions, getMajorMinecraftVersion, getMinorMinecraftVersion } from '../../scripts/dist/fabric-template-generator.js';
 
-const stableVersions = (await getGameVersions()).filter(x => x.stable);
+const stableVersions = (await getTemplateGameVersions()).filter(x => x.stable);
 
 const latestVersions = stableVersions.reduce((acc: Record<string, string>, x) => {
     const major = getMajorMinecraftVersion(x.version);

--- a/.github/scripts/template-versions.ts
+++ b/.github/scripts/template-versions.ts
@@ -1,7 +1,4 @@
 // @deno-types="../../scripts/dist/fabric-template-generator.d.ts"
 import { getTemplateGameVersions } from '../../scripts/dist/fabric-template-generator.js';
 
-const stableVersions = (await getTemplateGameVersions()).filter(x => x.stable);
-
-const result = stableVersions.map(({version}) => ({ branch: version, version }));
-console.log(JSON.stringify(result));
+console.log(JSON.stringify((await getTemplateGameVersions()).filter(x => x.stable).map(x => x.version)));

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -55,10 +55,6 @@ jobs:
       matrix:
         version: ${{ fromJSON(needs.build.outputs.versions) }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-        with:
-          sparse-checkout: .github/scripts/README.md
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
@@ -89,8 +85,6 @@ jobs:
       - name: Generate ${{ matrix.version.version }} template
         run: deno run -A ../bundled.ts init -n 'Example Mod' -m modid -p 'com.example' -v '${{ matrix.version.version }}' -o splitSources -o mojangMappings
         working-directory: gen
-      - name: Copy README into template
-        run: cp .github/scripts/README.md gen
       - name: Set commit user
         run: |
           git config user.name github-actions[bot]

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -82,8 +82,6 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
         working-directory: repo
-      - name: Copy new template
-        run: cp -RT gen repo
       - name: Commit changes
         run: |
           git --work-tree ../gen add .

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    outputs:
+      versions: ${{ steps.versions-lookup.outputs.result }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -60,25 +62,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        version:
-          - branch: '1.14'
-            version: '1.14.4'
-          - branch: '1.15'
-            version: '1.15.2'
-          - branch: '1.16'
-            version: '1.16.5'
-          - branch: '1.17'
-            version: '1.17.1'
-          - branch: '1.18'
-            version: '1.18.2'
-          - branch: '1.19'
-            version: '1.19.4'
-          - branch: '1.20'
-            version: '1.20.6'
-          - branch: '1.21'
-            version: '1.21.11'
-          - branch: '26.1'
-            version: '26.1.1'
+        version: ${{ fromJSON(needs.build.outputs.versions) }}
     steps:
       - uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -64,8 +64,7 @@ jobs:
         uses: actions/checkout@v6
         id: existing-checkout
         with:
-          repository: CelDaemon/fabric-example-mod
-          ref: master
+          repository: ${{ github.repository_owner }}/fabric-example-mod
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Switch to versioned branch
@@ -91,7 +90,7 @@ jobs:
       - name: Commit changes
         run: |
           git --work-tree ../gen add .
-          git diff-index --quiet --cached HEAD || git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
+          git diff-index --quiet --cached HEAD || git commit -m 'Deployment from commit ${{ github.repository }}@${{ github.sha }}'
         working-directory: repo
       - name: Push commit
         run: git push -u origin '${{ matrix.version.branch }}'

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -1,15 +1,8 @@
 name: Deploy to Fabric Example Mod
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - scripts/**
-      - cli/**
-      - .github/workflows/deploy-template.yml
-      - .github/scripts/README.md
-      - .github/scripts/template-versions.ts
+  schedule:
+    - cron: 37 7 * * SAT
 
 jobs:
   build:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -31,8 +31,29 @@ jobs:
         id: versions-lookup
         with:
           script: |
-            const { getGameVersions } = await import('${{ github.workspace }}/scripts/dist/fabric-template-generator.js');
-            return await getGameVersions();
+            const { getGameVersions, getMajorMinecraftVersion, getMinorMinecraftVersion } = await import('${{ github.workspace }}/scripts/dist/fabric-template-generator.js');
+            let previousMajor;
+            let previousMinor;
+            return (await getGameVersions()).filter(x => x.stable).filter(x => {
+              const major = getMajorMinecraftVersion(x.version);
+              const minor = getMinorMinecraftVersion(x.version);
+              return major > 1 || minor >= 14;
+            }).filter(x => {
+              const major = getMajorMinecraftVersion(x.version);
+              const minor = getMinorMinecraftVersion(x.version);
+              if(major == previousMajor && minor == previousMinor)
+                return false;
+              previousMajor = major;
+              previousMinor = minor;
+              return true
+            }).map(x => {
+              const major = getMajorMinecraftVersion(x.version);
+              const minor = getMinorMinecraftVersion(x.version);
+              return {
+                version: x.version,
+                branch: `${major}.${minor}`
+              };
+            });
       - run: printf "%s" '${{ steps.versions-lookup.outputs.result }}'
   deploy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -25,6 +25,7 @@ jobs:
           path: cli/bundled.ts
   deploy:
     runs-on: ubuntu-24.04
+    depends: build
     strategy:
       matrix:
         version:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ matrix.version.branch }}
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - run: deno run -A ../bundled.ts init -n "Example Mod" -n modid -p "com.example" -v "${{ matrix.version.version }}"
+      - run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}"
         working-directory: repo
       - name: Set Github Actions as commit user
         run: |

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -87,8 +87,8 @@ jobs:
         working-directory: gen
       - name: Set commit user
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name 'Fabric Bot'
+          git config user.email 159731069+FabricMCBot@users.noreply.github.com
         working-directory: repo
       - name: Commit changes
         run: |

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Commit changes
         run: |
           git add -A
-          git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
+          git diff-index --quiet HEAD || git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
           git push
         working-directory: repo
 

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -71,7 +71,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
         working-directory: repo
       - name: Copy new template
-        run: cp -r gen/* repo
+        run: cp -RT gen repo
       - name: Commit changes
         run: |
           git add -A

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -52,6 +52,10 @@ jobs:
       matrix:
         version: ${{ fromJSON(needs.build.outputs.versions) }}
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts/README.md
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
@@ -82,6 +86,8 @@ jobs:
       - name: Generate template
         run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}" -o splitSources -o mojangMappings
         working-directory: gen
+      - name: Copy README into template
+        run: cp .github/scripts/README.md gen
       - name: Set commit user
         run: |
           git config user.name github-actions[bot]

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           name: cli
           path: cli/bundled.ts
-      - run: deno run -A .github/scripts/template-versions.ts
+      - run: echo "result=$(deno run --allow-net .github/scripts/template-versions.ts)" >> "$GITHUB_OUTPUT"
         id: versions-lookup
   deploy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -1,0 +1,64 @@
+name: Deploy to Fabric Example Mod
+on:
+  push:
+    paths:
+      - scripts/lib/**/*
+      - cli/**/*
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 18
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: "2.1.10"
+      - run: make build
+        working-directory: cli
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cli
+          path: cli/bundled.ts
+  deploy:
+    runs-on: ubuntu-24.04
+    matrix:
+      version:
+        - branch: '1.17'
+          version: '1.17.1'
+        - branch: '1.18'
+          version: '1.18.2'
+        - branch: '1.19'
+          version: '1.19.4'
+        - branch: '1.20'
+          version: '1.20.6'
+        - branch: '1.21'
+          version: '1.21.11'
+        - branch: '26.1'
+          version: '26.1.1'
+    steps:
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: "2.1.10"
+      - uses: actions/download-artifact@v8
+        with:
+          name: cli
+      - uses: actions/checkout@v6
+        with:
+          repository: CelDaemon/fabric-example-mod
+          ref: ${{ matrix.version.branch }}
+          path: repo
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+      - run: deno bundled.ts init -n "Example Mod" -n modid -p "com.example" -v "${{ matrix.version.version }}"
+        working-directory: repo
+      - name: Set Github Actions as commit user
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Commit changes
+        run: |
+          git add -A
+          git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
+          git push

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -39,15 +39,11 @@ jobs:
             return (await getGameVersions()).filter(x => x.stable).filter(x => {
               const major = getMajorMinecraftVersion(x.version);
               const minor = getMinorMinecraftVersion(x.version);
-              return major > 1 || minor >= 14;
-            }).filter(x => {
-              const major = getMajorMinecraftVersion(x.version);
-              const minor = getMinorMinecraftVersion(x.version);
               if(major == previousMajor && minor == previousMinor)
                 return false;
               previousMajor = major;
               previousMinor = minor;
-              return true
+              return true;
             }).map(x => {
               const major = getMajorMinecraftVersion(x.version);
               const minor = getMinorMinecraftVersion(x.version);
@@ -56,7 +52,6 @@ jobs:
                 branch: `${major}.${minor}`
               };
             });
-      - run: printf "%s" '${{ steps.versions-lookup.outputs.result }}'
   deploy:
     runs-on: ubuntu-24.04
     needs: build

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/fabric-example-mod
           path: repo
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          ssh-key: ${{ secrets.EXAMPLE_MOD_DEPLOY_KEY }}
       - name: Switch to ${{ matrix.version }} branch
         run: |
           if git ls-remote --exit-code --quiet origin '${{ matrix.version }}'

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -25,7 +25,7 @@ jobs:
           path: cli/bundled.ts
   deploy:
     runs-on: ubuntu-24.04
-    depends: build
+    depend: build
     strategy:
       matrix:
         version:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -62,12 +62,15 @@ jobs:
           git rm -rf .
           git clean -fxd
         working-directory: repo
+      - run: mkdir gen
       - run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}"
-        working-directory: repo
+        working-directory: gen
       - name: Set Github Actions as commit user
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Copy new template
+        run: cp -r gen/* repo
       - name: Commit changes
         run: |
           git add -A

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -1,6 +1,8 @@
 name: Deploy to Fabric Example Mod
 on:
   push:
+    branches:
+      - main
     paths:
       - scripts/**
       - cli/**

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Commit changes
         run: |
           git --work-tree ../gen add .
-          git diff-index --quiet HEAD || git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
+          git diff-index --quiet --cached HEAD || git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
           git push -u origin '${{ matrix.version.branch }}'
         working-directory: repo
 

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -1,5 +1,6 @@
 name: Deploy to Fabric Example Mod
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ matrix.version.branch }}
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - run: deno run -A bundled.ts init -n "Example Mod" -n modid -p "com.example" -v "${{ matrix.version.version }}"
+      - run: deno run -A ../bundled.ts init -n "Example Mod" -n modid -p "com.example" -v "${{ matrix.version.version }}"
         working-directory: repo
       - name: Set Github Actions as commit user
         run: |

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: "2.1.10"
+      - run: npm i
+        working-directory: scripts
+      - run: npm run buildLib
+        working-directory: scripts
       - run: make build
         working-directory: cli
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -68,6 +68,7 @@ jobs:
       - run: |
           if git ls-remote --exit-code --quiet origin '${{ matrix.version.branch }}'
           then
+            git fetch origin '${{ matrix.version.branch }}'
             git switch '${{ matrix.version.branch }}'
           else
             git switch --orphan '${{ matrix.version.branch }}'

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -29,19 +29,8 @@ jobs:
         with:
           name: cli
           path: cli/bundled.ts
-      - uses: actions/github-script@v7
+      - run: deno run .github/scripts/template-versions.ts
         id: versions-lookup
-        with:
-          script: |
-            const { getGameVersions, getMajorMinecraftVersion, getMinorMinecraftVersion } = await import('${{ github.workspace }}/scripts/dist/fabric-template-generator.js');
-            const stableVersions = (await getGameVersions()).filter(x => x.stable);
-            const latestVersions = stableVersions.reduce((acc, x) => {
-              const major = getMajorMinecraftVersion(x.version);
-              const minor = getMinorMinecraftVersion(x.version);
-              acc[`${major}.${minor}`] ??= x.version;
-              return acc;
-            }, {});
-            return Object.entries(latestVersions).map(([branch, version]) => ({ branch, version }));
   deploy:
     runs-on: ubuntu-24.04
     needs: build

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -25,7 +25,7 @@ jobs:
           path: cli/bundled.ts
   deploy:
     runs-on: ubuntu-24.04
-    depend: build
+    needs: build
     strategy:
       matrix:
         version:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -2,8 +2,8 @@ name: Deploy to Fabric Example Mod
 on:
   push:
     paths:
-      - scripts/lib/**/*
-      - cli/**/*
+      - scripts/lib/**
+      - cli/**
       - .github/workflows/deploy-template.yml
 
 jobs:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -25,20 +25,21 @@ jobs:
           path: cli/bundled.ts
   deploy:
     runs-on: ubuntu-24.04
-    matrix:
-      version:
-        - branch: '1.17'
-          version: '1.17.1'
-        - branch: '1.18'
-          version: '1.18.2'
-        - branch: '1.19'
-          version: '1.19.4'
-        - branch: '1.20'
-          version: '1.20.6'
-        - branch: '1.21'
-          version: '1.21.11'
-        - branch: '26.1'
-          version: '26.1.1'
+    strategy:
+      matrix:
+        version:
+          - branch: '1.17'
+            version: '1.17.1'
+          - branch: '1.18'
+            version: '1.18.2'
+          - branch: '1.19'
+            version: '1.19.4'
+          - branch: '1.20'
+            version: '1.20.6'
+          - branch: '1.21'
+            version: '1.21.11'
+          - branch: '26.1'
+            version: '26.1.1'
     steps:
       - uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -8,50 +8,64 @@ on:
 
 jobs:
   build:
+    name: Build Fabric CLI
     runs-on: ubuntu-24.04
     outputs:
       versions: ${{ steps.versions-lookup.outputs.result }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+      - name: Setup NodeJS
+        uses: actions/setup-node@v6
         with:
           node-version: 18
-      - uses: denoland/setup-deno@v2
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
         with:
           deno-version: "2.1.10"
-      - run: npm i
+      - name: Install NPM dependencies
+        run: npm i
         working-directory: scripts
-      - run: npm run buildLib
+      - name: Build template library
+        run: npm run buildLib
         working-directory: scripts
-      - run: make build
+      - name: Build Fabric CLI
+        run: make build
         working-directory: cli
-      - uses: actions/upload-artifact@v7
+      - name: Upload Fabric CLI
+        uses: actions/upload-artifact@v7
         with:
           name: cli
           path: cli/bundled.ts
-      - run: echo "result=$(deno run --allow-net .github/scripts/template-versions.ts)" >> "$GITHUB_OUTPUT"
+      - name: Look up template versions
+        run: echo "result=$(deno run --allow-net .github/scripts/template-versions.ts)" >> "$GITHUB_OUTPUT"
         id: versions-lookup
   deploy:
+    name: Deploy to template repository
     runs-on: ubuntu-24.04
     needs: build
     strategy:
       matrix:
         version: ${{ fromJSON(needs.build.outputs.versions) }}
     steps:
-      - uses: denoland/setup-deno@v2
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
         with:
           deno-version: "2.1.10"
-      - uses: actions/download-artifact@v8
+      - name: Download Fabric CLI
+        uses: actions/download-artifact@v8
         with:
           name: cli
-      - uses: actions/checkout@v6
+      - name: Checkout template repository
+        uses: actions/checkout@v6
         id: existing-checkout
         with:
           repository: CelDaemon/fabric-example-mod
           ref: master
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - run: |
+      - name: Switch to versioned branch
+        run: |
           if git ls-remote --exit-code --quiet origin '${{ matrix.version.branch }}'
           then
             git fetch origin '${{ matrix.version.branch }}'
@@ -60,10 +74,12 @@ jobs:
             git switch --orphan '${{ matrix.version.branch }}'
           fi
         working-directory: repo
-      - run: mkdir gen
-      - run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}" -o splitSources -o mojangMappings
+      - name: Create template directory
+        run: mkdir gen
+      - name: Generate template
+        run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}" -o splitSources -o mojangMappings
         working-directory: gen
-      - name: Set Github Actions as commit user
+      - name: Set commit user
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
@@ -72,6 +88,8 @@ jobs:
         run: |
           git --work-tree ../gen add .
           git diff-index --quiet --cached HEAD || git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
-          git push -u origin '${{ matrix.version.branch }}'
+        working-directory: repo
+      - name: Push commit
+        run: git push -u origin '${{ matrix.version.branch }}'
         working-directory: repo
 

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -60,21 +60,18 @@ jobs:
           name: cli
       - uses: actions/checkout@v6
         id: existing-checkout
-        continue-on-error: true
-        with:
-          repository: CelDaemon/fabric-example-mod
-          ref: ${{ matrix.version.branch }}
-          path: repo
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - if: steps.existing-checkout.outcome == 'failure'
-        uses: actions/checkout@v6
         with:
           repository: CelDaemon/fabric-example-mod
           ref: master
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - if: steps.existing-checkout.outcome == 'failure'
-        run: git switch -c '${{ matrix.version.branch }}'
+      - run: |
+          if git show-ref --quiet 'refs/remotes/origin/${{ matrix.version.branch }}'
+          then
+            git switch '${{ matrix.version.branch }}'
+          else
+            git switch --orphan '${{ matrix.version.branch }}'
+          fi
         working-directory: repo
       - run: |
           git rm -rf .

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -34,24 +34,14 @@ jobs:
         with:
           script: |
             const { getGameVersions, getMajorMinecraftVersion, getMinorMinecraftVersion } = await import('${{ github.workspace }}/scripts/dist/fabric-template-generator.js');
-            let previousMajor;
-            let previousMinor;
-            return (await getGameVersions()).filter(x => x.stable).filter(x => {
+            const stableVersions = (await getGameVersions()).filter(x => x.stable);
+            const latestVersions = stableVersions.reduce((acc, x) => {
               const major = getMajorMinecraftVersion(x.version);
               const minor = getMinorMinecraftVersion(x.version);
-              if(major == previousMajor && minor == previousMinor)
-                return false;
-              previousMajor = major;
-              previousMinor = minor;
-              return true;
-            }).map(x => {
-              const major = getMajorMinecraftVersion(x.version);
-              const minor = getMinorMinecraftVersion(x.version);
-              return {
-                version: x.version,
-                branch: `${major}.${minor}`
-              };
-            });
+              acc[`${major}.${minor}`] ??= x.version;
+              return acc;
+            }, {});
+            return Object.entries(latestVersions).map(([branch, version]) => ({ branch, version }));
   deploy:
     runs-on: ubuntu-24.04
     needs: build

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - scripts/lib/**/*
       - cli/**/*
+      - .github/workflows/deploy-template.yml
 
 jobs:
   build:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           name: cli
           path: cli/bundled.ts
-      - run: deno run --allow-net .github/scripts/template-versions.ts
+      - run: deno run -A .github/scripts/template-versions.ts
         id: versions-lookup
   deploy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -70,11 +70,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: CelDaemon/fabric-example-mod
-          ref: main
+          ref: master
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
       - if: steps.existing-checkout.outcome == 'failure'
         run: git switch -c '${{ matrix.version.branch }}'
+        working-directory: repo
       - run: |
           git rm -rf .
           git clean -fxd

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ matrix.version.branch }}
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - run: deno bundled.ts init -n "Example Mod" -n modid -p "com.example" -v "${{ matrix.version.version }}"
+      - run: deno run -A bundled.ts init -n "Example Mod" -n modid -p "com.example" -v "${{ matrix.version.version }}"
         working-directory: repo
       - name: Set Github Actions as commit user
         run: |

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -58,7 +58,9 @@ jobs:
           ref: ${{ matrix.version.branch }}
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - run: rm -rf *
+      - run: |
+          git rm -rf .
+          git clean -fxd
         working-directory: repo
       - run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}"
         working-directory: repo

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           name: cli
           path: cli/bundled.ts
+      - uses: actions/github-script@v7
+        id: versions-lookup
+        with:
+          script: |
+            const { getGameVersions } = await import('${{ github.workspace }}/scripts/dist/fabric-template-generator.js');
+            return await getGameVersions();
+      - run: printf "%s" '${{ steps.versions-lookup.outputs.result }}'
   deploy:
     runs-on: ubuntu-24.04
     needs: build

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -66,7 +66,7 @@ jobs:
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
       - run: |
-          if git show-ref --quiet 'refs/remotes/origin/${{ matrix.version.branch }}'
+          if git ls-remote --exit-code --quiet origin '${{ matrix.version.branch }}'
           then
             git switch '${{ matrix.version.branch }}'
           else

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -74,10 +74,6 @@ jobs:
             git switch --orphan '${{ matrix.version.branch }}'
           fi
         working-directory: repo
-      - run: |
-          git rm -rf .
-          git clean -fxd
-        working-directory: repo
       - run: mkdir gen
       - run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}" -o splitSources -o mojangMappings
         working-directory: gen
@@ -90,7 +86,7 @@ jobs:
         run: cp -RT gen repo
       - name: Commit changes
         run: |
-          git add -A
+          git --work-tree ../gen add .
           git diff-index --quiet HEAD || git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
           git push -u origin '${{ matrix.version.branch }}'
         working-directory: repo

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -63,7 +63,7 @@ jobs:
           git clean -fxd
         working-directory: repo
       - run: mkdir gen
-      - run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}"
+      - run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}" -o splitSources -o mojangMappings
         working-directory: gen
       - name: Set Github Actions as commit user
         run: |

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -39,11 +39,11 @@ jobs:
         run: echo "result=$(deno run --allow-net .github/scripts/template-versions.ts)" >> "$GITHUB_OUTPUT"
         id: versions-lookup
   deploy:
-    name: Deploy ${{ matrix.version.version }} template
+    name: Deploy ${{ matrix.version }} template
     runs-on: ubuntu-24.04
     needs: build
     concurrency:
-      group: deploy-${{ matrix.version.branch }}
+      group: deploy-${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(needs.build.outputs.versions) }}
@@ -63,20 +63,20 @@ jobs:
           repository: ${{ github.repository_owner }}/fabric-example-mod
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - name: Switch to ${{ matrix.version.branch }} branch
+      - name: Switch to ${{ matrix.version }} branch
         run: |
-          if git ls-remote --exit-code --quiet origin '${{ matrix.version.branch }}'
+          if git ls-remote --exit-code --quiet origin '${{ matrix.version }}'
           then
-            git fetch origin '${{ matrix.version.branch }}'
-            git switch '${{ matrix.version.branch }}'
+            git fetch origin '${{ matrix.version }}'
+            git switch '${{ matrix.version }}'
           else
-            git switch --orphan '${{ matrix.version.branch }}'
+            git switch --orphan '${{ matrix.version }}'
           fi
         working-directory: repo
       - name: Create template directory
         run: mkdir gen
-      - name: Generate ${{ matrix.version.version }} template
-        run: deno run -A ../bundled.ts init -n 'Example Mod' -m modid -p 'com.example' -v '${{ matrix.version.version }}' -o splitSources -o mojangMappings
+      - name: Generate ${{ matrix.version }} template
+        run: deno run -A ../bundled.ts init -n 'Example Mod' -m modid -p 'com.example' -v '${{ matrix.version }}' -o splitSources -o mojangMappings
         working-directory: gen
       - name: Set commit user
         run: |
@@ -88,7 +88,7 @@ jobs:
           git --work-tree ../gen add .
           git diff-index --quiet --cached HEAD || git commit -m 'Deployment from commit ${{ github.repository }}@${{ github.sha }}'
         working-directory: repo
-      - name: Push to ${{ matrix.version.branch }}
-        run: git push -u origin '${{ matrix.version.branch }}'
+      - name: Push to ${{ matrix.version }}
+        run: git push -u origin '${{ matrix.version }}'
         working-directory: repo
 

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -59,11 +59,22 @@ jobs:
         with:
           name: cli
       - uses: actions/checkout@v6
+        id: existing-checkout
+        continue-on-error: true
         with:
           repository: CelDaemon/fabric-example-mod
           ref: ${{ matrix.version.branch }}
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+      - if: steps.existing-checkout.outcome == 'failure'
+        uses: actions/checkout@v6
+        with:
+          repository: CelDaemon/fabric-example-mod
+          ref: main
+          path: repo
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+      - if: steps.existing-checkout.outcome == 'failure'
+        run: git switch -c '${{ matrix.version.branch }}'
       - run: |
           git rm -rf .
           git clean -fxd
@@ -82,6 +93,6 @@ jobs:
         run: |
           git add -A
           git diff-index --quiet HEAD || git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
-          git push
+          git push -u origin '${{ matrix.version.branch }}'
         working-directory: repo
 

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -33,6 +33,12 @@ jobs:
     strategy:
       matrix:
         version:
+          - branch: '1.14'
+            version: '1.14.4'
+          - branch: '1.15'
+            version: '1.15.2'
+          - branch: '1.16'
+            version: '1.16.5'
           - branch: '1.17'
             version: '1.17.1'
           - branch: '1.18'

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -44,6 +44,8 @@ jobs:
     name: Deploy to template repository
     runs-on: ubuntu-24.04
     needs: build
+    concurrency:
+      group: deploy-${{ matrix.version.branch }}
     strategy:
       matrix:
         version: ${{ fromJSON(needs.build.outputs.versions) }}

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -58,6 +58,8 @@ jobs:
           ref: ${{ matrix.version.branch }}
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+      - run: rm -rf *
+        working-directory: repo
       - run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}"
         working-directory: repo
       - name: Set Github Actions as commit user

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -2,7 +2,7 @@ name: Deploy to Fabric Example Mod
 on:
   push:
     paths:
-      - scripts/lib/**
+      - scripts/**
       - cli/**
       - .github/workflows/deploy-template.yml
 

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -8,6 +8,8 @@ on:
       - scripts/**
       - cli/**
       - .github/workflows/deploy-template.yml
+      - .github/scripts/README.md
+      - .github/scripts/template-versions.ts
 
 jobs:
   build:
@@ -44,7 +46,7 @@ jobs:
         run: echo "result=$(deno run --allow-net .github/scripts/template-versions.ts)" >> "$GITHUB_OUTPUT"
         id: versions-lookup
   deploy:
-    name: Deploy to template repository
+    name: Deploy ${{ matrix.version.version }} template
     runs-on: ubuntu-24.04
     needs: build
     concurrency:
@@ -72,7 +74,7 @@ jobs:
           repository: ${{ github.repository_owner }}/fabric-example-mod
           path: repo
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - name: Switch to versioned branch
+      - name: Switch to ${{ matrix.version.branch }} branch
         run: |
           if git ls-remote --exit-code --quiet origin '${{ matrix.version.branch }}'
           then
@@ -84,8 +86,8 @@ jobs:
         working-directory: repo
       - name: Create template directory
         run: mkdir gen
-      - name: Generate template
-        run: deno run -A ../bundled.ts init -n "Example Mod" -m modid -p "com.example" -v "${{ matrix.version.version }}" -o splitSources -o mojangMappings
+      - name: Generate ${{ matrix.version.version }} template
+        run: deno run -A ../bundled.ts init -n 'Example Mod' -m modid -p 'com.example' -v '${{ matrix.version.version }}' -o splitSources -o mojangMappings
         working-directory: gen
       - name: Copy README into template
         run: cp .github/scripts/README.md gen
@@ -99,7 +101,7 @@ jobs:
           git --work-tree ../gen add .
           git diff-index --quiet --cached HEAD || git commit -m 'Deployment from commit ${{ github.repository }}@${{ github.sha }}'
         working-directory: repo
-      - name: Push commit
+      - name: Push to ${{ matrix.version.branch }}
         run: git push -u origin '${{ matrix.version.branch }}'
         working-directory: repo
 

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+        working-directory: repo
       - name: Copy new template
         run: cp -r gen/* repo
       - name: Commit changes
@@ -76,3 +77,5 @@ jobs:
           git add -A
           git commit -m 'Deployment from commit CelDaemon/fabricmc.net@${{ github.sha }}'
           git push
+        working-directory: repo
+

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           name: cli
           path: cli/bundled.ts
-      - run: deno run .github/scripts/template-versions.ts
+      - run: deno run --allow-net .github/scripts/template-versions.ts
         id: versions-lookup
   deploy:
     runs-on: ubuntu-24.04

--- a/scripts/src/lib/template/template.ts
+++ b/scripts/src/lib/template/template.ts
@@ -3,7 +3,7 @@ import { addGradleWrapper } from './gradlewrapper';
 import { getApiVersionForMinecraft, getKotlinAdapterVersions, getLoaderVersions, getMinecraftYarnVersions, type GameVersion, getGameVersions } from '../Api';
 import { addModJson } from './modjson';
 import { addGitFiles } from './git';
-import { minecraftIsUnobfuscated } from './minecraft';
+import { minecraftIsUnobfuscated, minecraftSupportsSplitSources, minecraftSupportsDataGen } from './minecraft';
 
 export const ICON_FONT = "Comic Relief";
 
@@ -111,6 +111,8 @@ async function computeConfig(options: Configuration): Promise<ComputedConfigurat
 	const unobfuscated = minecraftIsUnobfuscated(options.minecraftVersion);
 	return {
 		...options,
+        splitSources: minecraftSupportsSplitSources(options.minecraftVersion) && options.splitSources,
+        dataGeneration: minecraftSupportsDataGen(options.minecraftVersion) && options.dataGeneration,
 		loaderVersion: (await getLoaderVersions()).find((v) => v.stable)!.version,
 		fabricVersion: await getApiVersionForMinecraft(options.minecraftVersion),
 		yarnVersion: unobfuscated ? undefined : (await getMinecraftYarnVersions(options.minecraftVersion))[0].version,


### PR DESCRIPTION
This PR adds a deployment workflow that automatically deploys to the example mod repo.

A `DEPLOY_KEY` secret is required, which must be an SSH deploy key with write access to the example mod repository.

It is triggered when any push to the main branch affects the workflow itself, or any files in `scripts` or `cli`.

After being triggered, the workflow retrieves the list of currently supported Minecraft versions, and selects the ones to publish for. All major (release) versions will be used, with the latest minor version selected.
It will then generate a template for each of those versions, and publish to the corresponding existing branch, or to a new branch if one does not exist yet.

See https://github.com/CelDaemon/fabric-example-mod/ for the results of running this workflow on the current state of the repo.

P.S.

I also recommend turning off the webhook for the example mod, as many branches are pushed to at once.

#171 should also be merged to preserve the README.md in the generated template.