### PR TITLE
Add README.md to generated template

### DIFF
--- a/scripts/src/lib/template/git.ts
+++ b/scripts/src/lib/template/git.ts
@@ -1,13 +1,16 @@
 import type { ComputedConfiguration, TemplateWriter } from "./template";
+import { renderTemplate } from './eta';
 
 import gitattributes from './templates/git/gitattributes?raw';
 import gitignore from './templates/git/gitignore?raw';
 import workflow from './templates/git/workflow.yml?raw';
 import license from './templates/git/LICENSE?raw';
+import readme from './templates/git/README.md.eta?raw';
 
-export async function addGitFiles(writer: TemplateWriter, _config: ComputedConfiguration) {
+export async function addGitFiles(writer: TemplateWriter, config: ComputedConfiguration) {
     await writer.write('.gitattributes', gitattributes);
     await writer.write('.gitignore', gitignore);
     await writer.write('.github/workflows/build.yml', workflow);
     await writer.write('LICENSE', license);
+    await writer.write('README.md', renderTemplate(readme, config));
 }

--- a/scripts/src/lib/template/templates/git/README.md.eta
+++ b/scripts/src/lib/template/templates/git/README.md.eta
@@ -1,0 +1,9 @@
+# <%= it.projectName %>
+
+## Setup
+
+For setup instructions please see the [fabric documentation page](https://docs.fabricmc.net/develop/getting-started/creating-a-project#setting-up) that relates to the IDE that you are using.
+
+## License
+
+This template is available under the CC0 license. Feel free to learn from it and incorporate it in your own projects.

--- a/scripts/src/lib/template/templates/git/README.md.eta
+++ b/scripts/src/lib/template/templates/git/README.md.eta
@@ -2,7 +2,7 @@
 
 ## Setup
 
-For setup instructions please see the [fabric documentation page](https://docs.fabricmc.net/develop/getting-started/creating-a-project#setting-up) that relates to the IDE that you are using.
+For setup instructions, please see the [Fabric Documentation page](https://docs.fabricmc.net/develop/getting-started/creating-a-project#setting-up) related to the IDE that you are using.
 
 ## License
 


### PR DESCRIPTION
Adds a basic README.md to generated templates, like the one currently in the example mod repo.

This new README links to a section added by FabricMC/fabric-docs#565.