### PR TITLE
Update link to the portablemc launcher

### DIFF
--- a/_layouts/use.html
+++ b/_layouts/use.html
@@ -63,7 +63,7 @@ layout: page
             (Modpack Dev)
         </li>
         <li>
-            <a href="https://github.com/mindstorm38/portablemc">portablemc</a>
+            <a href="https://github.com/theorzr/portablemc">portablemc</a>
             (Command Line)
         </li>
         <li>


### PR DESCRIPTION
I (Théo Rozier) changed my GitHub username recently.

Edit: The link is currently properly redirected by GitHub, and I reserved the old username for safety, so it's low priority.