### PR TITLE
Simplify processResources props in template's build script

### DIFF
--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -49,11 +49,11 @@ dependencies {
 }
 
 processResources {
-	def version = project.version
-	inputs.property "version", version
+	def props = ["version": version]
+	inputs.properties props
 
 	filesMatching("fabric.mod.json") {
-		expand "version": version
+		expand props
 	}
 }
 

--- a/scripts/src/lib/template/templates/gradle/kotlin/build.gradle.kts.eta
+++ b/scripts/src/lib/template/templates/gradle/kotlin/build.gradle.kts.eta
@@ -48,11 +48,11 @@ dependencies {
 }
 
 tasks.processResources {
-	val version = version
-	inputs.property("version", version)
+	val props = mapOf("version" to version)
+	inputs.properties(props)
 
 	filesMatching("fabric.mod.json") {
-		expand("version" to version)
+		expand(props)
 	}
 }
 


### PR DESCRIPTION
moving the prop map outside of filesMatching makes the config cache Just Work

added a simple loop that adds all props from the map as inputs, to avoid duplication entirely