### PR TITLE
Gitignore .fabric in the template

### DIFF
--- a/scripts/src/lib/template/templates/git/gitignore
+++ b/scripts/src/lib/template/templates/git/gitignore
@@ -30,6 +30,7 @@ bin/
 
 # fabric
 
+.fabric/
 run/
 
 # java


### PR DESCRIPTION
its a directory with a bunch of jars output by auditing mixins