### PR TITLE
Fix mod initialiser class name starting with number

### DIFF
--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -210,7 +210,7 @@ async function promptUser(
 
   const packageName: string = cli.packageName ?? await Input.prompt({
     message: "Choose a package name",
-    default: generator.formatPackageName((Deno.env.get("FABRIC_MOD_GENERATOR_GLOBAL_PACKAGE_PREFIX") ?? "") + modId),
+    default: generator.generatePackageName((Deno.env.get("FABRIC_MOD_GENERATOR_GLOBAL_PACKAGE_PREFIX") ?? "") + modId),
     transform: (value) => {
       return generator.formatPackageName(value);
     },

--- a/scripts/src/lib/Template.svelte
+++ b/scripts/src/lib/Template.svelte
@@ -3,8 +3,8 @@
     import FileSaver from "file-saver";
     import DownloadIcon from "./DownloadIcon.svelte";
     import { ICON_FONT, getTemplateGameVersions, type Configuration } from "./template/template";
-    import { minecraftSupportsDataGen, minecraftSupportsSplitSources, computeCustomModIdErrors, sharedModIdChecks, formatPackageName, nameToModId, minecraftIsUnobfuscated} from "./template/minecraft";
-    import { computePackageNameErrors } from "./template/java"
+    import { minecraftSupportsDataGen, minecraftSupportsSplitSources, computeCustomModIdErrors, sharedModIdChecks, nameToModId, minecraftIsUnobfuscated} from "./template/minecraft";
+    import { computePackageNameErrors, formatPackageName } from "./template/java"
     import { decode64 } from "./template/utils";
 
     let minecraftVersion: string;

--- a/scripts/src/lib/template/java.ts
+++ b/scripts/src/lib/template/java.ts
@@ -116,9 +116,9 @@ export function formatClassname(projectName: string): string {
 
 export function formatPackageName(packageName: string): string {
     return packageName
-        .toLocaleLowerCase()
+        .toLowerCase()
         .replaceAll(/\s+/g, '.')
-        .replaceAll(/[^a-za-z0-9_\.]/g, "");
+        .replaceAll(/[^a-z0-9_\.]/g, "");
 }
 
 export function generatePackageName(packageName: string): string | undefined {

--- a/scripts/src/lib/template/java.ts
+++ b/scripts/src/lib/template/java.ts
@@ -97,6 +97,23 @@ export function computePackageNameErrors(packageName: string): string[] {
 	return errorList;
 }
 
+function capitalize(s: string): string {
+    return s[0].toUpperCase() + s.slice(1);
+}
+
+function toPascalCase(parts: string[]): string {
+    return parts
+        .filter(s => s)
+        .map(capitalize)
+        .join('');
+}
+
+export function formatClassname(projectName: string): string {
+    const s = toPascalCase(projectName.split(/\b/).map(s => s.replaceAll(/\W/g, '')));
+    const [numerals, rest] = convertNumericPrefix(s);
+    return `${toPascalCase(numerals)}${capitalize(rest)}`;
+}
+
 export function formatPackageName(packageName: string): string {
     return packageName
         .toLocaleLowerCase()
@@ -105,7 +122,9 @@ export function formatPackageName(packageName: string): string {
 }
 
 export function generatePackageName(packageName: string): string | undefined {
-    const formatted = replaceNumerals(formatPackageName(packageName)).join('');
+    const [numerals, rest] = convertNumericPrefix(formatPackageName(packageName));
+
+    const formatted = `${numerals.join('')}${rest}`;
 
     if(computePackageNameErrors(formatted).length !== 0)
         return;
@@ -126,14 +145,11 @@ const NUMERALS = [
     'nine'
 ] as const;
 
-export function replaceNumerals(s: string): string[] {
+export function convertNumericPrefix(s: string): [string[], string] {
     const match = s.match(/^\d+/);
     if(!(match && match[0]))
-        return [s];
+        return [[], s];
     const numericPrefix = match[0];
     const rest = s.substring(numericPrefix.length);
-    const out: string[] = numericPrefix.split('').map(x => NUMERALS[parseInt(x)]);
-    if(rest)
-        out.push(rest);
-    return out;
+    return [numericPrefix.split('').map(x => NUMERALS[parseInt(x)]), rest];
 }

--- a/scripts/src/lib/template/java.ts
+++ b/scripts/src/lib/template/java.ts
@@ -97,59 +97,54 @@ export function computePackageNameErrors(packageName: string): string[] {
 	return errorList;
 }
 
-function capitalize(s: string): string {
-    return s[0].toUpperCase() + s.slice(1);
+const NUMERALS = [
+	'zero',
+	'one',
+	'two',
+	'three',
+	'four',
+	'five',
+	'six',
+	'seven',
+	'eight',
+	'nine'
+] as const;
+
+function convertNumericPrefix(s: string): string[] {
+	const match = s.match(/^\d+/);
+	if(!(match && match[0]))
+		return [s];
+	const numericPrefix = match[0];
+	const rest = s.substring(numericPrefix.length);
+	return [...numericPrefix.split('').map(x => NUMERALS[parseInt(x)]), rest];
 }
 
 function toPascalCase(parts: string[]): string {
-    return parts
-        .filter(s => s)
-        .map(capitalize)
-        .join('');
+	return parts
+		.filter(Boolean)
+		.map(s => s[0].toUpperCase() + s.slice(1))
+		.join('');
 }
 
 export function formatClassname(projectName: string): string {
-    const s = toPascalCase(projectName.split(/\b/).map(s => s.replaceAll(/\W/g, '')));
-    const [numerals, rest] = convertNumericPrefix(s);
-    return `${toPascalCase(numerals)}${capitalize(rest)}`;
+	const s = toPascalCase(projectName.split(/\b/).map(s => s.replaceAll(/\W/g, '')));
+	return toPascalCase(convertNumericPrefix(s));
 }
 
 export function formatPackageName(packageName: string): string {
-    return packageName
-        .toLowerCase()
-        .replaceAll(/\s+/g, '.')
-        .replaceAll(/[^a-z0-9_\.]/g, "");
+	return packageName
+		.toLowerCase()
+		.replaceAll(/[\s/]+/g, '.')
+		.replaceAll(/[^a-z0-9_\.]/g, "");
 }
 
 export function generatePackageName(packageName: string): string | undefined {
-    const [numerals, rest] = convertNumericPrefix(formatPackageName(packageName));
+	const formatted = convertNumericPrefix(formatPackageName(packageName))
+		.join('');
 
-    const formatted = `${numerals.join('')}${rest}`;
+	if(computePackageNameErrors(formatted).length !== 0)
+		return;
 
-    if(computePackageNameErrors(formatted).length !== 0)
-        return;
-
-    return formatted;
+	return formatted;
 }
 
-const NUMERALS = [
-    'zero',
-    'one',
-    'two',
-    'three',
-    'four',
-    'five',
-    'six',
-    'seven',
-    'eight',
-    'nine'
-] as const;
-
-export function convertNumericPrefix(s: string): [string[], string] {
-    const match = s.match(/^\d+/);
-    if(!(match && match[0]))
-        return [[], s];
-    const numericPrefix = match[0];
-    const rest = s.substring(numericPrefix.length);
-    return [numericPrefix.split('').map(x => NUMERALS[parseInt(x)]), rest];
-}

--- a/scripts/src/lib/template/java.ts
+++ b/scripts/src/lib/template/java.ts
@@ -96,3 +96,44 @@ export function computePackageNameErrors(packageName: string): string[] {
 
 	return errorList;
 }
+
+export function formatPackageName(packageName: string): string {
+    return packageName
+        .toLocaleLowerCase()
+        .replaceAll(/\s+/g, '.')
+        .replaceAll(/[^a-za-z0-9_\.]/g, "");
+}
+
+export function generatePackageName(packageName: string): string | undefined {
+    const formatted = replaceNumerals(formatPackageName(packageName)).join('');
+
+    if(computePackageNameErrors(formatted).length !== 0)
+        return;
+
+    return formatted;
+}
+
+const NUMERALS = [
+    'zero',
+    'one',
+    'two',
+    'three',
+    'four',
+    'five',
+    'six',
+    'seven',
+    'eight',
+    'nine'
+] as const;
+
+export function replaceNumerals(s: string): string[] {
+    const match = s.match(/^\d+/);
+    if(!(match && match[0]))
+        return [s];
+    const numericPrefix = match[0];
+    const rest = s.substring(numericPrefix.length);
+    const out: string[] = numericPrefix.split('').map(x => NUMERALS[parseInt(x)]);
+    if(rest)
+        out.push(rest);
+    return out;
+}

--- a/scripts/src/lib/template/minecraft.ts
+++ b/scripts/src/lib/template/minecraft.ts
@@ -93,9 +93,6 @@ export function computeCustomModIdErrors(id: string | undefined): string[] | und
 	return errorList;
 }
 
-export function formatPackageName(packageName: string): string {
-	return packageName.toLocaleLowerCase().replaceAll(/\s+/g, '.').replaceAll(/[^a-za-z0-9_\.]/g, "")
-}
 
 export function nameToModId(name: string) {
 	return name.toLowerCase().replaceAll(/\s+/g, '-').replaceAll(/[^a-za-z0-9-_]/g, "");

--- a/scripts/src/lib/template/modentrypoint.ts
+++ b/scripts/src/lib/template/modentrypoint.ts
@@ -8,7 +8,7 @@ import kotlinEntrypointClientTemplate from './templates/entrypoint/ClientEntrypo
 import javaEntrypointDataGeneratorTemplate from './templates/entrypoint/DataGeneratorEntrypoint.java.eta?raw';
 import kotlinEntrypointDataGeneratorTemplate from './templates/entrypoint/DataGeneratorEntrypoint.kt.eta?raw';
 import { minecraftSupportsSlf4j } from "./minecraft";
-import { replaceNumerals } from "./java";
+import { formatClassname } from "./java";
 
 interface ClassOptions {
     package: string, // com.example
@@ -49,17 +49,6 @@ export async function generateEntrypoint(writer: TemplateWriter, options: Comput
 }
 
 
-function formatClassname(projectName: string): string {
-    return projectName.split(' ')
-        .map(s => s?.replaceAll(/\W/g, ""))
-        .filter(s => s)
-        .flatMap((s, i) => {
-            if(i !== 0) return s;
-            return replaceNumerals(s);
-        })
-        .map(s => s[0].toUpperCase() + s.slice(1))
-        .join("")
-}
 
 async function generateJavaEntrypoint(writer: TemplateWriter, options: ClassOptions): Promise<unknown> {
     var entrypoints: any = {

--- a/scripts/src/lib/template/modentrypoint.ts
+++ b/scripts/src/lib/template/modentrypoint.ts
@@ -47,11 +47,41 @@ export async function generateEntrypoint(writer: TemplateWriter, options: Comput
     }
 }
 
+const NUMERALS = [
+    'zero',
+    'one',
+    'two',
+    'three',
+    'four',
+    'five',
+    'six',
+    'seven',
+    'eight',
+    'nine'
+] as const;
+
+function replaceNumerals(s: string): string[] | string {
+    const match = s.match(/^\d+/);
+    if(!(match && match[0]))
+        return s;
+    const numericPrefix = match[0];
+    const rest = s.substring(numericPrefix.length);
+    const out: string[] = numericPrefix.split('').map(x => NUMERALS[parseInt(x)]);
+    if(rest)
+        out.push(rest);
+    return out;
+}
+
 function formatClassname(projectName: string): string {
     return projectName.split(' ')
+        .map(s => s?.replaceAll(/\W/g, ""))
+        .filter(s => s)
+        .flatMap((s, i) => {
+            if(i !== 0) return s;
+            return replaceNumerals(s);
+        })
         .map(s => s[0].toUpperCase() + s.slice(1))
         .join("")
-        .replace(/\W+/g, "");
 }
 
 async function generateJavaEntrypoint(writer: TemplateWriter, options: ClassOptions): Promise<unknown> {

--- a/scripts/src/lib/template/modentrypoint.ts
+++ b/scripts/src/lib/template/modentrypoint.ts
@@ -8,6 +8,7 @@ import kotlinEntrypointClientTemplate from './templates/entrypoint/ClientEntrypo
 import javaEntrypointDataGeneratorTemplate from './templates/entrypoint/DataGeneratorEntrypoint.java.eta?raw';
 import kotlinEntrypointDataGeneratorTemplate from './templates/entrypoint/DataGeneratorEntrypoint.kt.eta?raw';
 import { minecraftSupportsSlf4j } from "./minecraft";
+import { replaceNumerals } from "./java";
 
 interface ClassOptions {
     package: string, // com.example
@@ -47,30 +48,6 @@ export async function generateEntrypoint(writer: TemplateWriter, options: Comput
     }
 }
 
-const NUMERALS = [
-    'zero',
-    'one',
-    'two',
-    'three',
-    'four',
-    'five',
-    'six',
-    'seven',
-    'eight',
-    'nine'
-] as const;
-
-function replaceNumerals(s: string): string[] | string {
-    const match = s.match(/^\d+/);
-    if(!(match && match[0]))
-        return s;
-    const numericPrefix = match[0];
-    const rest = s.substring(numericPrefix.length);
-    const out: string[] = numericPrefix.split('').map(x => NUMERALS[parseInt(x)]);
-    if(rest)
-        out.push(rest);
-    return out;
-}
 
 function formatClassname(projectName: string): string {
     return projectName.split(' ')


### PR DESCRIPTION
Fixes invalid generated class names when the project name starts with a number. Also prevents a crash when the project contains multiple spaces after each other.