### PR TITLE
Fix grammar and punctuation in Minecraft 26.1 post

### DIFF
--- a/_posts/2026-03-14-261.md
+++ b/_posts/2026-03-14-261.md
@@ -3,13 +3,13 @@ layout: post
 title: Fabric for Minecraft 26.1
 ref: 261
 ---
-A new version of Minecraft is coming soon with changes that will affect all mod makers. As always, **we ask all players to be patient, and give mod developers time to update to this new version**. We kindly ask everyone not to pester them. **We also recommend all players make backups of their worlds, especially due to the major changes to world storage in this version**.
+A new version of Minecraft is coming soon with changes that will affect all mod makers. As always, **we ask all players to be patient and give mod developers time to update to this new version**. We kindly ask everyone not to pester them. **We also recommend all players make backups of their worlds, especially due to the major changes to world storage in this version**.
 
 <p align="center">
   <img src="/assets/forklift.png" style="max-width: 400px; height: auto;" alt="Tiny Potato in a fork lift, by Superkat32">
 </p>
 
-Preparing Fabric to support and full embrace the changes in 26.1 has been a major focus for the last several months by many contributors. The changes in the tooling and API are the largest we have ever made for a single release. There are still some rough edges and missing features however the changes put us in a great position to continue to update and improve Fabric for the foreseeable future. We are excited to see what the community will create with the new possibilities that 26.1 opens up.
+Preparing Fabric to support and fully embrace the changes in 26.1 has been a major focus for the last several months for many contributors. The changes in the tooling and API are the largest we have ever made for a single release. There are still some rough edges and missing features; however, the changes put us in a great position to continue to update and improve Fabric for the foreseeable future. We are excited to see what the community will create with the new possibilities that 26.1 opens up.
 
 [26.1 is the first version of Minecraft to not be obfuscated](https://fabricmc.net/2025/10/31/obfuscation.html). Because of that, **no mods from 1.21.11 or before will work without, at a minimum, recompilation.** If you have not yet [transitioned your mods to Mojang's mappings](https://docs.fabricmc.net/develop/migrating-mappings/), now is the time to do so, as Yarn is no longer officially supported by Fabric.
 
@@ -21,9 +21,9 @@ Here is a list of several major modder-facing changes in this version. Note that
 
 Developers should use Loom 1.15 and Gradle 9.4.0 (at the time of writing) to develop mods for Minecraft 26.1. Players should install the latest stable version of Fabric Loader (currently 0.18.4).
 
-Minecraft 26.1 requires **Java 25** minimum for the Gradle JVM. You can configure this in your IDE's Gradle Settings. Additionally, if you are using IntelliJ IDEA, version **2025.3** or above is required for mixins to work correctly.
+Minecraft 26.1 requires **Java 25** minimum for the Gradle JVM. You can configure this in your IDE's Gradle settings. Additionally, if you are using IntelliJ IDEA, version **2025.3** or above is required for mixins to work correctly.
 
-Note: The Fabric Model Loading API and Renderer/Indigo modules may not be available for the inital release of 26.1, but we hope to have them updated as soon as they are ready. If you are interested in helping with the development of these modules, please reach out to us on our Discord server.
+Note: The Fabric Model Loading API and Renderer/Indigo modules may not be available for the initial release of 26.1, but we hope to have them updated as soon as they are ready. If you are interested in helping with the development of these modules, please reach out to us on our Discord server.
 
 ### Deprecations and removals
 
@@ -33,7 +33,7 @@ The following previously deprecated modules have been removed.
 - `fabric-convention-tags-v1`
 - `fabric-loot-api-v2`
 
-In addition, deprecated conventional tags labeled for removal in 1.22 have finally been removed ([#5056](https://github.com/FabricMC/fabric-api/pull/5056)), and the deprecated `HudRenderCallback` event has been removed in favour of `HudElementRegistry`. As always, other APIs have been changed in response to 26.1 refactors, see below for more information.
+In addition, deprecated conventional tags labeled for removal in 1.22 have finally been removed ([#5056](https://github.com/FabricMC/fabric-api/pull/5056)), and the deprecated `HudRenderCallback` event has been removed in favor of `HudElementRegistry`. As always, other APIs have been changed in response to 26.1 refactors; see below for more information.
 
 ### Unobfuscated Loom
 
@@ -51,7 +51,7 @@ For a full list of changes, as well as an IntelliJ IDEA migration map to automat
 
 #### Dimension events
 
-Rather than use the biome modification API to iterate through and modifying every individual biome within a dimension, Fabric now provides an event that directly interacts with a dimension's attributes. Datapack and modpack creators still retain granular control, as dimension-level modifications are designed with lower priority than biome-specific definitions during attribute evaluation in vanilla.
+Rather than use the biome modification API to iterate through and modify every individual biome within a dimension, Fabric now provides an event that directly interacts with a dimension's attributes. Datapack and modpack creators still retain granular control, as dimension-level modifications are designed with lower priority than biome-specific definitions during attribute evaluation in vanilla.
 ```java
 DimensionEvents.MODIFY_ATTRIBUTES.register((dimension, attributes, registries) -> {
   if (dimension.is(BuiltinDimensionTypes.OVERWORLD)) {
@@ -62,7 +62,7 @@ DimensionEvents.MODIFY_ATTRIBUTES.register((dimension, attributes, registries) -
 
 #### Block/Item events
 
-Fabric now provides 4 new events which allow for more precise modification of item/block use interactions.
+Fabric now provides 4 new events, which allow for more precise modification of item/block use interactions.
 Compared to the existing `UseBlockCallback` and `UseItemCallback` events, these new events run only in specific contexts and keep the rest of vanilla logic around the use method calls.
 
 - `BlockEvents#USE_ITEM_ON` - called before `Block#useItemOn`, replacing it for non-null returns.
@@ -88,15 +88,15 @@ BlockColorRegistry.register(List.of(new BlockTintSource() {
 
 ## Minecraft changes
 
-26.1 is a very large update with many changes, especially to the rendering engine. We have only listed a few of the major non-rendering changes here. For a more comprehensive list of changes we look forward to Neoforged's upcoming porting "primer".
+26.1 is a very large update with many changes, especially to the rendering engine. We have only listed a few of the major non-rendering changes here. For a more comprehensive list of changes, we look forward to Neoforge's upcoming porting "primer."
 
 ### ItemStackTemplate
 
-An `ItemStack` can no longer be created until a world is loaded. As a replacement, the game provides a new class, `ItemStackTemplate`, an immutable class representing an non-empty `Item`, a count, and a `DataComponentPatch`. Many methods that used to return an `ItemStack` now return an `ItemStackTemplate`. Note that until the world is launched, components on an `ItemStackTemplate` are not bound and the game will throw if they are accessed too early.
+An `ItemStack` can no longer be created until a world is loaded. As a replacement, the game provides a new class, `ItemStackTemplate`, an immutable class representing a non-empty `Item`, a count, and a `DataComponentPatch`. Many methods that used to return an `ItemStack` now return an `ItemStackTemplate`. Note that until the world is launched, components on an `ItemStackTemplate` are not bound, and the game will throw if they are accessed too early.
 
 ### Recipe serializers
 
-Rather than having every recipe have an inner class than implements `RecipeSerializer`, recipe serializers have been simplified to just be a `MapCodec` and `StreamCodec`. 
+Rather than having every recipe have an inner class that implements `RecipeSerializer`, recipe serializers have been simplified to just be a `MapCodec` and `StreamCodec`. 
 
 ```java
 Registry.register(BuiltInRegistries.RECIPE_SERIALIZE, "mod_recipe", new RecipeSerializer<>(ModRecipe.CODEC, ModRecipe.STREAM_CODEC));
@@ -113,10 +113,10 @@ BlockRenderLayerMap.INSTANCE.putBlock(MyModBlocks.TATER_GLASS_BLOCK, RenderLayer
 BlockRenderLayerMap.putBlock(MyModBlocks.TATER_GLASS_BLOCK, BlockRenderLayer.TRANSLUCENT);
 ```
 
-…Minecraft now automatically sets the `ChunkSectionLayer` for each quad based on the assigned sprite's properties which are as follows:
- - Translucency: the sprite has translucent pixels
- - Cutout: the sprite has only solid and transparent pixels
- - Solid: the sprite has no transparency or translucency
+…Minecraft now automatically sets the `ChunkSectionLayer` for each quad based on the assigned sprite's properties, which are as follows:
+ - Translucency: the sprite has translucent pixels.
+ - Cutout: the sprite has only solid and transparent pixels.
+ - Solid: the sprite has no transparency or translucency.
 
 This can be overridden with a [block model]() or with `MutableQuadView` and Model Loading API.
 
@@ -125,7 +125,7 @@ This can be overridden with a [block model]() or with `MutableQuadView` and Mode
 Villager trading, including Wandering Traders, has been made data-driven in 26.1, removing the need for Fabric's `TradeOfferHelper` API. A [villager trade](https://minecraft.wiki/w/Villager_trade_definition) is stored in the new `data/<namespace>/villager_trade` directory, a [set of trades](https://minecraft.wiki/w/Trade_set) is defined in the `data/<namespace>/trade_set` folder, which uses tags in the `data/minecraft/tags/villager_trade/<profession>` folders.
 
 In general, to add your mod's trade to an existing profession:
-1. Create a new [villager trade](https://minecraft.wiki/w/Villager_trade_definition) in `data/<namespace>/villager_trade`
+1. Create a new [villager trade](https://minecraft.wiki/w/Villager_trade_definition) in `data/<namespace>/villager_trade`.
 2. Add it to the appropriate tag in `data/minecraft/tags/villager_trade/<profession>`.
 
 
@@ -135,4 +135,4 @@ The new `FluidModel` replaces a lot of functionality previously provided by Fabr
 
 ## mcsrc.dev
 
-Over the last few months we have been developing [mcsrc.dev](https://mcsrc.dev), a new online tool to view the decompiled source code of Minecraft. It works by downloading the Minecraft jar directly from Mojang's servers, decompiling it with Vineflower that has been compiled to WASM. mcsrc.dev also provides tools to aid with creating mixins and AccessWideners/ClassTweakers. We have plans to use this as the base for a javadoc editor that will allow users to provide documentation for Minecraft, this is still in the early stages of development.
+Over the last few months we have been developing [mcsrc.dev](https://mcsrc.dev), a new online tool to view the decompiled source code of Minecraft. It works by downloading the Minecraft jar directly from Mojang's servers and decompiling it with Vineflower that has been compiled to WASM. mcsrc.dev also provides tools to aid with creating mixins and AccessWideners/ClassTweakers. We have plans to use this as the base for a javadoc editor that will allow users to provide documentation for Minecraft, but this is still in the early stages of development.

--- a/_posts/2026-03-14-261.md
+++ b/_posts/2026-03-14-261.md
@@ -88,7 +88,7 @@ BlockColorRegistry.register(List.of(new BlockTintSource() {
 
 ## Minecraft changes
 
-26.1 is a very large update with many changes, especially to the rendering engine. We have only listed a few of the major non-rendering changes here. For a more comprehensive list of changes, we look forward to Neoforge's upcoming porting "primer."
+26.1 is a very large update with many changes, especially to the rendering engine. We have only listed a few of the major non-rendering changes here. For a more comprehensive list of changes, we look forward to Neoforged's upcoming porting "primer."
 
 ### ItemStackTemplate
 


### PR DESCRIPTION
Corrected grammar and punctuation for clarity and consistency throughout the post.