### PR TITLE
Add an Identifier helper to the entrypoint class

### DIFF
--- a/scripts/src/lib/template/modentrypoint.ts
+++ b/scripts/src/lib/template/modentrypoint.ts
@@ -13,7 +13,7 @@ import { formatClassname } from "./java";
 interface IdentifierNames {
     package: string, // net.minecraft.resources
     class: string, // Identifier
-    factoryName: string // fromNamespaceAndPath,
+    factoryName: string // fromNamespaceAndPath
 }
 
 interface IdentifierOptions extends IdentifierNames {
@@ -46,8 +46,7 @@ function getIdentifierFactory(names: IdentifierNames, version: string): string {
 }
 
 function getIdentifierNames(options: ComputedConfiguration): IdentifierNames {
-    const isYarn = !(options.unobfuscated || options.mojmap);
-    if(isYarn) {
+    if(!(options.unobfuscated || options.mojmap)) {
         return {
             package: 'net.minecraft.util',
             class: 'Identifier',

--- a/scripts/src/lib/template/modentrypoint.ts
+++ b/scripts/src/lib/template/modentrypoint.ts
@@ -7,8 +7,18 @@ import javaEntrypointClientTemplate from './templates/entrypoint/ClientEntrypoin
 import kotlinEntrypointClientTemplate from './templates/entrypoint/ClientEntrypoint.kt.eta?raw';
 import javaEntrypointDataGeneratorTemplate from './templates/entrypoint/DataGeneratorEntrypoint.java.eta?raw';
 import kotlinEntrypointDataGeneratorTemplate from './templates/entrypoint/DataGeneratorEntrypoint.kt.eta?raw';
-import { minecraftSupportsSlf4j } from "./minecraft";
+import { getMajorMinecraftVersion, getMinorMinecraftVersion, getPatchMinecraftVersion, minecraftSupportsSlf4j } from "./minecraft";
 import { formatClassname } from "./java";
+
+interface IdentifierNames {
+    package: string, // net.minecraft.resources
+    class: string, // Identifier
+    factoryName: string // fromNamespaceAndPath,
+}
+
+interface IdentifierOptions extends IdentifierNames {
+    factory: string // Identifier.fromNamespaceAndPath / new ResourceLocation
+}
 
 interface ClassOptions {
     package: string, // com.example
@@ -22,6 +32,49 @@ interface ClassOptions {
     slf4j: boolean,
     clientEntrypoint: boolean,
     dataEntrypoint: boolean,
+    identifier: IdentifierOptions
+}
+
+function getIdentifierFactory(names: IdentifierNames, version: string): string {
+    const major = getMajorMinecraftVersion(version);
+    const minor = getMinorMinecraftVersion(version);
+
+    if(major > 1 || minor > 20)
+        return `${names.class}.${names.factoryName}`;
+
+    return `new ${names.class}`;
+}
+
+function getIdentifierNames(options: ComputedConfiguration): IdentifierNames {
+    const isYarn = !(options.unobfuscated || options.mojmap);
+    if(isYarn) {
+        return {
+            package: 'net.minecraft.util',
+            class: 'Identifier',
+            factoryName: 'of'
+        };
+    }
+    const major = getMajorMinecraftVersion(options.minecraftVersion);
+    const minor = getMinorMinecraftVersion(options.minecraftVersion);
+    const patch = getPatchMinecraftVersion(options.minecraftVersion);
+
+    const clazz = (major > 1 || (minor == 21 && patch == 11)) ? 'Identifier' : 'ResourceLocation';
+
+    return {
+        package: 'net.minecraft.resources',
+        class: clazz,
+        factoryName: 'fromNamespaceAndPath'
+    };
+}
+
+function buildIdentifierOptions(options: ComputedConfiguration): IdentifierOptions {
+    const names = getIdentifierNames(options);
+    const factory = getIdentifierFactory(names, options.minecraftVersion);
+
+    return {
+        ...names,
+        factory
+    };
 }
 
 export async function generateEntrypoint(writer: TemplateWriter, options: ComputedConfiguration): Promise<unknown> {
@@ -38,7 +91,8 @@ export async function generateEntrypoint(writer: TemplateWriter, options: Comput
         modid: options.modid,
         slf4j: minecraftSupportsSlf4j(options.minecraftVersion),
         clientEntrypoint: options.splitSources,
-        dataEntrypoint: options.dataGeneration
+        dataEntrypoint: options.dataGeneration,
+        identifier: buildIdentifierOptions(options)
     }
 
     if (options.kotlin) {

--- a/scripts/src/lib/template/modentrypoint.ts
+++ b/scripts/src/lib/template/modentrypoint.ts
@@ -11,23 +11,37 @@ import { getMajorMinecraftVersion, getMinorMinecraftVersion, getPatchMinecraftVe
 import { formatClassname } from "./java";
 
 interface IdentifierNames {
-    package: string, // net.minecraft.resources
-    class: string, // Identifier
-    factoryName: string // fromNamespaceAndPath
+    /** @example net.minecraft.resources */
+    package: string,
+    /** @example Identifier */
+    class: string,
+    /** @example fromNamespaceAndPath */
+    factoryName: string
 }
 
 interface IdentifierOptions extends IdentifierNames {
-    factory: string // Identifier.fromNamespaceAndPath / new ResourceLocation
+    /**
+     * @example Identifier.fromNamespaceAndPath
+     * @example new ResourceLocation
+     */
+    factory: string
 }
 
 interface ClassOptions {
-    package: string, // com.example
-    clientPackage: string // com.example.client
-    className: string, // ExampleClass
-    classFullName: string, // com.example.ExampleClass
-    clientClassFullName: string // com.example.client.ExampleClass
-    path: string, // com/example/ExampleClass
-    clientPath: string, // com/example/client/ExampleClass
+    /** @example com.example */
+    package: string,
+    /** @example com.example.client */
+    clientPackage: string
+    /** @example ExampleClass */
+    className: string,
+    /** @example com.example.ExampleClass */
+    classFullName: string,
+    /** @example com.example.client.ExampleClass */
+    clientClassFullName: string
+    /** @example com/example/ExampleClass */
+    path: string,
+    /** @example com/example/client/ExampleClass */
+    clientPath: string,
     modid: string,
     slf4j: boolean,
     clientEntrypoint: boolean,

--- a/scripts/src/lib/template/templates/entrypoint/Entrypoint.java.eta
+++ b/scripts/src/lib/template/templates/entrypoint/Entrypoint.java.eta
@@ -1,6 +1,8 @@
 package <%= it.package %>;
 
 import net.fabricmc.api.ModInitializer;
+
+import <%= it.identifier.package %>.<%= it.identifier.class %>;
 <% if (it.slf4j) { %>
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,5 +25,9 @@ public class <%= it.className %> implements ModInitializer {
 		// Proceed with mild caution.
 
 		LOGGER.info("Hello Fabric world!");
+	}
+
+	public static <%= it.identifier.class %> id(String path) {
+		return <%= it.identifier.factory %>(MOD_ID, path);
 	}
 }

--- a/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
+++ b/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
@@ -7,13 +7,13 @@ import <%= it.identifier.package %>.<%= it.identifier.class %>
 object <%= it.className %> : ModInitializer {
 	const val MOD_ID: String = "<%= it.modid %>"
 
-<% if (it.slf4j) { %>    private val logger = LoggerFactory.getLogger("<%= it.modid %>")
-<% } else { %>    private val logger = LogManager.getLogger("<%= it.modid %>")<% } %>
+<% if (it.slf4j) { %>    private val LOGGER = LoggerFactory.getLogger("<%= it.modid %>")
+<% } else { %>    private val LOGGER = LogManager.getLogger("<%= it.modid %>")<% } %>
 	override fun onInitialize() {
 		// This code runs as soon as Minecraft is in a mod-load-ready state.
 		// However, some things (like resources) may still be uninitialized.
 		// Proceed with mild caution.
-		logger.info("Hello Fabric world!")
+		LOGGER.info("Hello Fabric world!")
 	}
 
 	fun id(path: String): <%= it.identifier.class %>

--- a/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
+++ b/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
@@ -1,15 +1,22 @@
 package <%= it.package %>
 
 import net.fabricmc.api.ModInitializer
+import <%= it.identifier.package %>.<%= it.identifier.class %>
 <% if (it.slf4j) { %>import org.slf4j.LoggerFactory
 <% } else { %>import org.apache.logging.log4j.LogManager<% } %>
 object <%= it.className %> : ModInitializer {
+	const val MOD_ID: String = "<%= it.modid %>"
+
 <% if (it.slf4j) { %>    private val logger = LoggerFactory.getLogger("<%= it.modid %>")
 <% } else { %>    private val logger = LogManager.getLogger("<%= it.modid %>")<% } %>
+
 	override fun onInitialize() {
 		// This code runs as soon as Minecraft is in a mod-load-ready state.
 		// However, some things (like resources) may still be uninitialized.
 		// Proceed with mild caution.
 		logger.info("Hello Fabric world!")
 	}
+
+	fun id(path: String): <%= it.identifier.class %>
+		= <%= it.identifier.factory %>(MOD_ID, path)
 }

--- a/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
+++ b/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
@@ -7,8 +7,8 @@ import <%= it.identifier.package %>.<%= it.identifier.class %>
 object <%= it.className %> : ModInitializer {
 	const val MOD_ID: String = "<%= it.modid %>"
 
-<% if (it.slf4j) { %>    private val LOGGER = LoggerFactory.getLogger("<%= it.modid %>")
-<% } else { %>    private val LOGGER = LogManager.getLogger("<%= it.modid %>")<% } %>
+<% if (it.slf4j) { %>    private val LOGGER = LoggerFactory.getLogger(MOD_ID)
+<% } else { %>    private val LOGGER = LogManager.getLogger(MOD_ID)<% } %>
 	override fun onInitialize() {
 		// This code runs as soon as Minecraft is in a mod-load-ready state.
 		// However, some things (like resources) may still be uninitialized.

--- a/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
+++ b/scripts/src/lib/template/templates/entrypoint/Entrypoint.kt.eta
@@ -9,7 +9,6 @@ object <%= it.className %> : ModInitializer {
 
 <% if (it.slf4j) { %>    private val logger = LoggerFactory.getLogger("<%= it.modid %>")
 <% } else { %>    private val logger = LogManager.getLogger("<%= it.modid %>")<% } %>
-
 	override fun onInitialize() {
 		// This code runs as soon as Minecraft is in a mod-load-ready state.
 		// However, some things (like resources) may still be uninitialized.


### PR DESCRIPTION
This allows us to use `ExampleMod.id("test")` instead of `Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "test")`.