### PR TITLE
Fix recipe sync version number

### DIFF
--- a/_posts/2025-12-5-12111.md
+++ b/_posts/2025-12-5-12111.md
@@ -31,7 +31,7 @@ Implementing the packet splitter is simple - use the new `registerLarge` method 
 PayloadTypeRegistry.playS2C().registerLarge(YourPayload.ID, YourPayload.CODEC, DATA_SIZE);
 ```
 
-Thanks to this API, Fabric also now offers a way for mods to synchronize recipes from the server to the client, comparable to the behavior prior to 1.21.1. This API has already been adopted by recipe viewers like JEI, but means that recipe viewers are required on the server.
+Thanks to this API, Fabric also now offers a way for mods to synchronize recipes from the server to the client, comparable to the behavior prior to 1.21.2. This API has already been adopted by recipe viewers like JEI, but means that recipe viewers are required on the server.
 
 ```java
 RecipeSynchronization.synchronizeRecipeSerializer(YourRecipeSerializers.RECIPE_TYPE);


### PR DESCRIPTION
Mojang broke recipe viewers in 1.21.2, not 1.21.1.