### PR TITLE
Simplify setting group and version

### DIFF
--- a/scripts/src/lib/template/templates/gradle/gradle.properties.eta
+++ b/scripts/src/lib/template/templates/gradle/gradle.properties.eta
@@ -18,8 +18,8 @@ fabric_kotlin_version=<%= it.kotlin.fabricKotlinAdapterVersion %>
 <% } -%>
 
 # Mod Properties
-mod_version=1.0.0
-maven_group=<%= it.packageName %>
+version=1.0.0
+group=<%= it.packageName %>
 
 # Dependencies
 fabric_api_version=<%= it.fabricVersion %>

--- a/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
+++ b/scripts/src/lib/template/templates/gradle/groovy/build.gradle.eta
@@ -11,9 +11,6 @@ plugins {
 <% } -%>
 }
 
-version = project.mod_version
-group = project.maven_group
-
 repositories {
 	// Add repositories to retrieve artifacts from in here.
 	// You should only use this when depending on other mods because

--- a/scripts/src/lib/template/templates/gradle/kotlin/build.gradle.kts.eta
+++ b/scripts/src/lib/template/templates/gradle/kotlin/build.gradle.kts.eta
@@ -11,9 +11,6 @@ plugins {
 <% } -%>
 }
 
-version = providers.gradleProperty("mod_version").get()
-group = providers.gradleProperty("maven_group").get()
-
 repositories {
 	// Add repositories to retrieve artifacts from in here.
 	// You should only use this when depending on other mods because


### PR DESCRIPTION
Instead of manually looking up properties using
providers.gradleProperty(...), gradle automatically searches for the "version" and group" in the gradle.properties