### PR TITLE
Define permissions inside template workflow

### DIFF
--- a/scripts/src/lib/template/templates/git/workflow.yml
+++ b/scripts/src/lib/template/templates/git/workflow.yml
@@ -5,6 +5,8 @@
 
 name: build
 on: [pull_request, push]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
This defines actions permissions inside the workflow file inside the template mod.  
GitHub CodeQL complains about missing permissions when it's enabled.

<img width="1920" height="271" alt="image showing a screenshot of the warning with the header 'Workflow does not contain permissions'" src="https://github.com/user-attachments/assets/d00f66f0-288a-4f76-8856-aa433cc301b1" />

Functionality doesn't change. Example: https://github.com/Onako2/WorldLoot/actions/runs/31880241478